### PR TITLE
Multi-Prompt Data Parallel

### DIFF
--- a/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
+++ b/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
@@ -340,10 +340,10 @@ class DPSamplerCustom:
         comfy.model_management.soft_empty_cache()
         gpu_actors = ray_actors["workers"]
 
-        if len(positive) != len(gpu_actors):
-            positive = [positive[0]] * len(gpu_actors)
-        if len(negative) != len(gpu_actors):
-            negative = [negative[0]] * len(gpu_actors)
+        if len(positive) == 1:
+            positive = positive * len(gpu_actors)
+        if len(negative) == 1:
+            negative = negative * len(gpu_actors)
 
         futures = [
             actor.custom_sampler.remote(

--- a/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
+++ b/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
@@ -331,10 +331,6 @@ class DPSamplerCustom:
         ray_actors = ray_actors[0]
         add_noise = add_noise[0]
         cfg = cfg[0]
-        if len(positive) != len(gpu_actors):
-            positive = [positive[0]] * len(gpu_actors)
-        if len(negative) != len(gpu_actors):
-            negative = [negative[0]] * len(gpu_actors)
         sampler = sampler[0]
         sigmas = sigmas[0]
         latent_image = latent_image[0]
@@ -343,6 +339,11 @@ class DPSamplerCustom:
         comfy.model_management.unload_all_models()
         comfy.model_management.soft_empty_cache()
         gpu_actors = ray_actors["workers"]
+
+        if len(positive) != len(gpu_actors):
+            positive = [positive[0]] * len(gpu_actors)
+        if len(negative) != len(gpu_actors):
+            negative = [negative[0]] * len(gpu_actors)
 
         futures = [
             actor.custom_sampler.remote(

--- a/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
+++ b/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
@@ -331,8 +331,10 @@ class DPSamplerCustom:
         ray_actors = ray_actors[0]
         add_noise = add_noise[0]
         cfg = cfg[0]
-        positive = positive[0]
-        negative = negative[0]
+        if len(positive) != len(gpu_actors):
+            positive = [positive[0]] * len(gpu_actors)
+        if len(negative) != len(gpu_actors):
+            negative = [negative[0]] * len(gpu_actors)
         sampler = sampler[0]
         sigmas = sigmas[0]
         latent_image = latent_image[0]
@@ -347,8 +349,8 @@ class DPSamplerCustom:
                 add_noise,
                 noise_list[i],
                 cfg,
-                positive,
-                negative,
+                positive[i],
+                negative[i],
                 sampler,
                 sigmas,
                 latent_image,

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -625,10 +625,10 @@ class DPKSamplerAdvanced:
 
         if len(latent_image) != len(gpu_actors):
             latent_image = [latent_image[0]] * len(gpu_actors)
-        if len(positive) != len(gpu_actors):
-            positive = [positive[0]] * len(gpu_actors)
-        if len(negative) != len(gpu_actors):
-            negative = [negative[0]] * len(gpu_actors)
+        if len(positive) == 1:
+            positive = positive * len(gpu_actors)
+        if len(negative) == 1:
+            negative = negative * len(gpu_actors)
 
         # Clean VRAM for preparation to load model
         gc.collect()

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -608,10 +608,6 @@ class DPKSamplerAdvanced:
         cfg = cfg[0]
         sampler_name = sampler_name[0]
         scheduler = scheduler[0]
-        if len(positive) != len(gpu_actors):
-            positive = [positive[0]] * len(gpu_actors)
-        if len(negative) != len(gpu_actors):
-            negative = [negative[0]] * len(gpu_actors)
         start_at_step = start_at_step[0]
         end_at_step = end_at_step[0]
         return_with_leftover_noise = return_with_leftover_noise[0]
@@ -629,6 +625,10 @@ class DPKSamplerAdvanced:
 
         if len(latent_image) != len(gpu_actors):
             latent_image = [latent_image[0]] * len(gpu_actors)
+        if len(positive) != len(gpu_actors):
+            positive = [positive[0]] * len(gpu_actors)
+        if len(negative) != len(gpu_actors):
+            negative = [negative[0]] * len(gpu_actors)
 
         # Clean VRAM for preparation to load model
         gc.collect()

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -714,13 +714,17 @@ class DPConditioningList:
     def INPUT_TYPES(cls):
         return {
             "required": {
+                "positive_0": ("CONDITIONING",),
+                "negative_0": ("CONDITIONING",),
+            },
+            "optional": {
                 **{
                     f"positive_{i}": ("CONDITIONING",)
-                    for i in range(8)
+                    for i in range(1, 8)
                 },
                 **{
                     f"negative_{i}": ("CONDITIONING",)
-                    for i in range(8)
+                    for i in range(1, 8)
                 },
             }
         }
@@ -731,14 +735,12 @@ class DPConditioningList:
     FUNCTION = "assemble"
     CATEGORY = "Raylight"
 
-    def assemble(self, **kwargs):
-        positives = []
-        negatives = []
-        for key, value in kwargs.items():
-            if key.startswith("positive_"):
-                positives.append(value)
-            elif key.startswith("negative_"):
-                negatives.append(value)
+    def assemble(self, positive_0, negative_0, **kwargs):
+        positives = [positive_0]
+        negatives = [negative_0]
+        for i in range(1, 8):
+            positives.append(kwargs.get(f"positive_{i}", positive_0))
+            negatives.append(kwargs.get(f"negative_{i}", negative_0))
         return (positives, negatives)
 
 

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -714,13 +714,13 @@ class DPConditioningList:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "positive_1": ("CONDITIONING",),
-                "negative_1": ("CONDITIONING",),
+                "positive_0": ("CONDITIONING",),
+                "negative_0": ("CONDITIONING",),
             },
             "optional": {
                 **{
                     k: ("CONDITIONING",)
-                    for i in range(2, 9)
+                    for i in range(1, 8)
                     for k in (f"positive_{i}", f"negative_{i}")
                 },
             }
@@ -732,12 +732,12 @@ class DPConditioningList:
     FUNCTION = "assemble"
     CATEGORY = "Raylight"
 
-    def assemble(self, positive_1, negative_1, **kwargs):
-        positives = [positive_1]
-        negatives = [negative_1]
-        for i in range(2, 9):
-            positives.append(kwargs.get(f"positive_{i}", positive_1))
-            negatives.append(kwargs.get(f"negative_{i}", negative_1))
+    def assemble(self, positive_0, negative_0, **kwargs):
+        positives = [positive_0]
+        negatives = [negative_0]
+        for i in range(1, 8):
+            positives.append(kwargs.get(f"positive_{i}", positive_0))
+            negatives.append(kwargs.get(f"negative_{i}", negative_0))
         return (positives, negatives)
 
 

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -608,8 +608,10 @@ class DPKSamplerAdvanced:
         cfg = cfg[0]
         sampler_name = sampler_name[0]
         scheduler = scheduler[0]
-        positive = positive[0]
-        negative = negative[0]
+        if len(positive) != len(gpu_actors):
+            positive = [positive[0]] * len(gpu_actors)
+        if len(negative) != len(gpu_actors):
+            negative = [negative[0]] * len(gpu_actors)
         start_at_step = start_at_step[0]
         end_at_step = end_at_step[0]
         return_with_leftover_noise = return_with_leftover_noise[0]
@@ -646,8 +648,8 @@ class DPKSamplerAdvanced:
                 cfg,
                 sampler_name,
                 scheduler,
-                positive,
-                negative,
+                positive[i],
+                negative[i],
                 latent_image[i],
                 denoise=denoise,
                 disable_noise=disable_noise,

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -709,6 +709,39 @@ class DPNoiseList:
         return (noise_list,)
 
 
+class DPConditioningList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                **{
+                    f"positive_{i}": ("CONDITIONING",)
+                    for i in range(8)
+                },
+                **{
+                    f"negative_{i}": ("CONDITIONING",)
+                    for i in range(8)
+                },
+            }
+        }
+
+    RETURN_TYPES = ("CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("positive", "negative")
+    OUTPUT_IS_LIST = (True, True)
+    FUNCTION = "assemble"
+    CATEGORY = "Raylight"
+
+    def assemble(self, **kwargs):
+        positives = []
+        negatives = []
+        for key, value in kwargs.items():
+            if key.startswith("positive_"):
+                positives.append(value)
+            elif key.startswith("negative_"):
+                negatives.append(value)
+        return (positives, negatives)
+
+
 class RayVAEDecodeDistributed:
     @classmethod
     def INPUT_TYPES(s):
@@ -774,6 +807,7 @@ NODE_CLASS_MAPPINGS = {
     "RayInitializer": RayInitializer,
     "RayInitializerAdvanced": RayInitializerAdvanced,
     "DPNoiseList": DPNoiseList,
+    "DPConditioningList": DPConditioningList,
     "RayVAEDecodeDistributed": RayVAEDecodeDistributed,
 }
 
@@ -785,5 +819,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "RayInitializer": "Ray Init Actor",
     "RayInitializerAdvanced": "Ray Init Actor (Advanced)",
     "DPNoiseList": "Data Parallel Noise List",
+    "DPConditioningList": "Data Parallel Conditioning List",
     "RayVAEDecodeDistributed": "Distributed VAE (Ray)",
 }

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -714,17 +714,14 @@ class DPConditioningList:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "positive_0": ("CONDITIONING",),
-                "negative_0": ("CONDITIONING",),
+                "positive_1": ("CONDITIONING",),
+                "negative_1": ("CONDITIONING",),
             },
             "optional": {
                 **{
-                    f"positive_{i}": ("CONDITIONING",)
-                    for i in range(1, 8)
-                },
-                **{
-                    f"negative_{i}": ("CONDITIONING",)
-                    for i in range(1, 8)
+                    k: ("CONDITIONING",)
+                    for i in range(2, 9)
+                    for k in (f"positive_{i}", f"negative_{i}")
                 },
             }
         }
@@ -735,12 +732,12 @@ class DPConditioningList:
     FUNCTION = "assemble"
     CATEGORY = "Raylight"
 
-    def assemble(self, positive_0, negative_0, **kwargs):
-        positives = [positive_0]
-        negatives = [negative_0]
-        for i in range(1, 8):
-            positives.append(kwargs.get(f"positive_{i}", positive_0))
-            negatives.append(kwargs.get(f"negative_{i}", negative_0))
+    def assemble(self, positive_1, negative_1, **kwargs):
+        positives = [positive_1]
+        negatives = [negative_1]
+        for i in range(2, 9):
+            positives.append(kwargs.get(f"positive_{i}", positive_1))
+            negatives.append(kwargs.get(f"negative_{i}", negative_1))
         return (positives, negatives)
 
 


### PR DESCRIPTION
## TL;DR

**What:** Enable multi-prompt Data Parallel — each GPU receives a different positive/negative prompt instead of the same prompt with different seeds.
**Why:** DP mode could only produce N variations of the same prompt. Users need N different prompts in parallel (e.g., different character descriptions, A/B test prompts).
**How:** Added `DPConditioningList` node (assembles up to 8 per-GPU conditionings into lists). Modified `DPKSamplerAdvanced` and `DPSamplerCustom` to dispatch per-GPU conditioning instead of a single shared one. Fully backward compatible — single conditioning auto-replicates to all GPUs.

## What

2 files changed, 50 insertions, 8 deletions:

- **`src/raylight/nodes.py`** — Added `DPConditioningList` node (8 positive + 8 negative optional CONDITIONING inputs, returns two CONDITIONING lists via `OUTPUT_IS_LIST`). Modified `DPKSamplerAdvanced.ray_sample()`: replaced single `positive[0]`/`negative[0]` collapse with per-GPU auto-replicate (`len == 1` → replicate) and indexed dispatch `positive[i]`/`negative[i]`. Registered in both `NODE_CLASS_MAPPINGS` and `NODE_DISPLAY_NAME_MAPPINGS`.
- **`src/raylight/comfy_extra_dist/nodes_custom_sampler.py`** — Same pattern applied to `DPSamplerCustom.ray_sample()`: removed single-conditioning collapse, added auto-replicate guard, indexed dispatch.

## Why

Data Parallel mode distributed the same prompt across N GPUs with only noise varying per GPU. To get different prompts, users had to run N separate workflows sequentially. This adds per-GPU prompt support with zero overhead — same parallel execution, different conditioning per worker.

## How

**DPConditioningList** follows the `DPNoiseList` pattern: 8 slots (matching max GPU count), `positive_1`/`negative_1` required, rest optional with first-value fallback. Returns `(CONDITIONING list, CONDITIONING list)` via `OUTPUT_IS_LIST`. Inputs are grouped per-GPU (positive_1, negative_1, positive_2, negative_2, ...) for intuitive wiring.

**Sampler auto-replicate:** When `len(positive) == 1` (single CLIPTextEncode connected directly, backward compat), replicates to all GPU actors. When `len > 1` (from DPConditioningList), passes each element to the corresponding GPU. Same for negative.

**Dispatch:** `positive[i]` and `negative[i]` in the per-GPU remote call, matching the existing `latent_image[i]` and `noise_list[i]` pattern.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `raylight` — Data Parallel sampling

## Breaking changes

- [x] No breaking changes — existing single-conditioning workflows auto-replicate identically to before

## Test plan

- [x] Manual testing — multi-prompt DP workflow with 3 different prompts, verified each GPU produced distinct output
- [x] Backward compatibility — existing single-prompt DP workflow unchanged, produces identical results
- [ ] No automated tests — runtime requires multi-GPU Ray cluster
