### PR TITLE
fix: add missing tools/convert.py for GGUF arch detection

### DIFF
--- a/src/raylight/expansion/comfyui_gguf/tools/__init__.py
+++ b/src/raylight/expansion/comfyui_gguf/tools/__init__.py
@@ -1,0 +1,1 @@
+# (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)

--- a/src/raylight/expansion/comfyui_gguf/tools/convert.py
+++ b/src/raylight/expansion/comfyui_gguf/tools/convert.py
@@ -1,0 +1,182 @@
+# (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)
+# Vendored from https://github.com/city96/ComfyUI-GGUF — tools/convert.py
+# Only the architecture detection classes and detect_arch() are needed at runtime.
+# The conversion logic (convert_file, handle_tensors, etc.) is omitted.
+
+import os
+import torch
+
+
+class ModelTemplate:
+    arch = "invalid"  # string describing architecture
+    shape_fix = False # whether to reshape tensors
+    keys_detect = []  # list of lists to match in state dict
+    keys_banned = []  # list of keys that should mark model as invalid for conversion
+    keys_hiprec = []  # list of keys that need to be kept in fp32 for some reason
+    keys_ignore = []  # list of strings to ignore keys by when found
+
+    def handle_nd_tensor(self, key, data):
+        raise NotImplementedError(f"Tensor detected that exceeds dims supported by C++ code! ({key} @ {data.shape})")
+
+
+class ModelFlux(ModelTemplate):
+    arch = "flux"
+    keys_detect = [
+        ("transformer_blocks.0.attn.norm_added_k.weight",),
+        ("double_blocks.0.img_attn.proj.weight",),
+    ]
+    keys_banned = ["transformer_blocks.0.attn.norm_added_k.weight"]
+
+
+class ModelSD3(ModelTemplate):
+    arch = "sd3"
+    keys_detect = [
+        ("transformer_blocks.0.attn.add_q_proj.weight",),
+        ("joint_blocks.0.x_block.attn.qkv.weight",),
+    ]
+    keys_banned = ["transformer_blocks.0.attn.add_q_proj.weight"]
+
+
+class ModelAura(ModelTemplate):
+    arch = "aura"
+    keys_detect = [
+        ("double_layers.3.modX.1.weight",),
+        ("joint_transformer_blocks.3.ff_context.out_projection.weight",),
+    ]
+    keys_banned = ["joint_transformer_blocks.3.ff_context.out_projection.weight"]
+
+
+class ModelHiDream(ModelTemplate):
+    arch = "hidream"
+    keys_detect = [
+        (
+            "caption_projection.0.linear.weight",
+            "double_stream_blocks.0.block.ff_i.shared_experts.w3.weight"
+        )
+    ]
+    keys_hiprec = [
+        # nn.parameter, can't load from BF16 ver
+        ".ff_i.gate.weight",
+        "img_emb.emb_pos"
+    ]
+
+
+class CosmosPredict2(ModelTemplate):
+    arch = "cosmos"
+    keys_detect = [
+        (
+            "blocks.0.mlp.layer1.weight",
+            "blocks.0.adaln_modulation_cross_attn.1.weight",
+        )
+    ]
+    keys_hiprec = ["pos_embedder"]
+    keys_ignore = ["_extra_state", "accum_"]
+
+
+class ModelHyVid(ModelTemplate):
+    arch = "hyvid"
+    keys_detect = [
+        (
+            "double_blocks.0.img_attn_proj.weight",
+            "txt_in.individual_token_refiner.blocks.1.self_attn_qkv.weight",
+        )
+    ]
+
+
+class ModelWan(ModelHyVid):
+    arch = "wan"
+    keys_detect = [
+        (
+            "blocks.0.self_attn.norm_q.weight",
+            "text_embedding.2.weight",
+            "head.modulation",
+        )
+    ]
+    keys_hiprec = [
+        ".modulation" # nn.parameter, can't load from BF16 ver
+    ]
+
+
+class ModelLTXV(ModelTemplate):
+    arch = "ltxv"
+    keys_detect = [
+        (
+            "adaln_single.emb.timestep_embedder.linear_2.weight",
+            "transformer_blocks.27.scale_shift_table",
+            "caption_projection.linear_2.weight",
+        )
+    ]
+    keys_hiprec = [
+        "scale_shift_table" # nn.parameter, can't load from BF16 base quant
+    ]
+
+
+class ModelSDXL(ModelTemplate):
+    arch = "sdxl"
+    shape_fix = True
+    keys_detect = [
+        ("down_blocks.0.downsamplers.0.conv.weight", "add_embedding.linear_1.weight",),
+        (
+            "input_blocks.3.0.op.weight", "input_blocks.6.0.op.weight",
+            "output_blocks.2.2.conv.weight", "output_blocks.5.2.conv.weight",
+        ), # Non-diffusers
+        ("label_emb.0.0.weight",),
+    ]
+
+
+class ModelSD1(ModelTemplate):
+    arch = "sd1"
+    shape_fix = True
+    keys_detect = [
+        ("down_blocks.0.downsamplers.0.conv.weight",),
+        (
+            "input_blocks.3.0.op.weight", "input_blocks.6.0.op.weight", "input_blocks.9.0.op.weight",
+            "output_blocks.2.1.conv.weight", "output_blocks.5.2.conv.weight", "output_blocks.8.2.conv.weight"
+        ), # Non-diffusers
+    ]
+
+
+class ModelLumina2(ModelTemplate):
+    arch = "lumina2"
+    keys_detect = [
+        ("cap_embedder.1.weight", "context_refiner.0.attention.qkv.weight")
+    ]
+
+
+arch_list = [
+    ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2,
+    ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2,
+]
+
+
+def is_model_arch(model, state_dict):
+    """Check if model matches the given architecture template.
+
+    ``state_dict`` can be a real dict or any container supporting ``in``
+    (e.g. a set of key names), which is how ``loader.py`` calls us.
+    """
+    matched = False
+    invalid = False
+    for match_list in model.keys_detect:
+        if all(key in state_dict for key in match_list):
+            matched = True
+            invalid = any(key in state_dict for key in model.keys_banned)
+            break
+    if invalid:
+        raise AssertionError(
+            "Model architecture not allowed for conversion! "
+            "(i.e. reference VS diffusers format)"
+        )
+    return matched
+
+
+def detect_arch(state_dict):
+    """Return a ``ModelTemplate`` subclass instance matching *state_dict*."""
+    model_arch = None
+    for arch_cls in arch_list:
+        if is_model_arch(arch_cls, state_dict):
+            model_arch = arch_cls()
+            break
+    if model_arch is None:
+        raise AssertionError("Unknown model architecture!")
+    return model_arch


### PR DESCRIPTION
Some GGUF files (e.g. flux2-dev-q4_k_m.gguf) lack general.architecture metadata, causing the loader to fall back to detect_arch() from tools/convert.py. That module was never committed to the repo (vendored from City96/ComfyUI-GGUF).

Add tools/convert.py with detect_arch() and all ModelTemplate subclasses from upstream so old sd.cpp-compat GGUF models can be loaded successfully.