### PR TITLE
fix: prevent cloudpickle from losing model config during Ray transfer

### DIFF
--- a/src/raylight/comfy_dist/__init__.py
+++ b/src/raylight/comfy_dist/__init__.py
@@ -1,4 +1,6 @@
 # Distributed version of comfy library
+import logging
+
 from . import lora
 from . import sd
 from . import utils
@@ -6,11 +8,40 @@ from . import model_patcher
 from . import float
 from . import supported_models_base
 
+
+def patch_base_getattr():
+    """Patch BASE.__getattr__ to raise AttributeError for dunder methods.
+
+    ComfyUI's BASE.__getattr__ returns None for missing attributes.
+    When cloudpickle checks hasattr(obj, '__getstate__') it gets None
+    (truthy), then calls None() -> loses instance attrs or TypeError.
+    Raising AttributeError for dunder methods makes cloudpickle fall back
+    to __dict__-based (de)serialization.
+
+    Must be called in both the main process (before Ray serialization)
+    and in Ray worker processes (before Ray deserialization).
+    """
+    import comfy.supported_models_base
+
+    def _safe_getattr(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        logging.warning(f"WARNING: Missing config attribute '{name}'")
+
+        def _dummy(*args, **kwargs):
+            logging.warning(f"Called missing attribute {name}")
+            return None
+        return _dummy
+
+    setattr(comfy.supported_models_base.BASE, "__getattr__", _safe_getattr)
+
+
 __all__ = [
     "lora",
     "sd",
     "model_patcher",
     "float",
     "utils",
-    "supported_models_base"
+    "supported_models_base",
+    "patch_base_getattr",
 ]

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -42,6 +42,8 @@ from ray.exceptions import RayActorError
 # Comfy cli args, does not get pass through into ray actor
 class RayWorker:
     def __init__(self, local_rank, device_id, parallel_dict):
+        from raylight.comfy_dist import patch_base_getattr
+        patch_base_getattr()
         self.model = None
         self.vae_model = None
         self.model_type = None

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -1,6 +1,7 @@
 import raylight
 import os
 import gc
+import logging
 from typing import Any
 from pathlib import Path
 from copy import deepcopy
@@ -24,13 +25,8 @@ from .distributed_worker.ray_worker import (
 # Workaround https://github.com/comfyanonymous/ComfyUI/pull/11134
 # since in FSDPModelPatcher mode, ray cannot pickle None type cause by getattr
 def _monkey():
-    from raylight.comfy_dist.supported_models_base import BASE as PatchedBASE
-    import comfy.supported_models_base as supported_models_base
-
-    OriginalBASE = supported_models_base.BASE
-
-    if hasattr(PatchedBASE, "__getattr__"):
-        setattr(OriginalBASE, "__getattr__", PatchedBASE.__getattr__)
+    from raylight.comfy_dist import patch_base_getattr
+    patch_base_getattr()
 
 
 def _resolve_module_dir(module):


### PR DESCRIPTION
`BASE.__getattr__` returns `None` (or a dummy callable) for missing attributes instead of raising `AttributeError`. When cloudpickle checks `hasattr(obj, '__getstate__')`, it gets a truthy value and calls it, receiving `None` as state. This loses all instance-level `unet_config` keys (e.g. `out_channels`) during Ray serialization to worker processes, causing `KeyError` on non-zero ranks.

Fix by patching `__getattr__` to raise `AttributeError` for dunder methods, making cloudpickle fall back to `__dict__`-based pickling. Applied in both main process (via `_monkey`) and Ray workers (via `RayWorker.__init__`) to cover serialization and deserialization.

Closes #61

--
tested with flux.2-dev full precision model