### PR TITLE
Fix non-fsdp (data parallel) model unload, reload with lora enabled/disabled

### DIFF
--- a/src/raylight/comfy_dist/model_patcher.py
+++ b/src/raylight/comfy_dist/model_patcher.py
@@ -83,6 +83,11 @@ def free_model_vram(model_patcher) -> None:
     Unlike model.detach(), this does NOT copy weights to CPU RAM.
     Call before dropping the model reference so VRAM is released
     deterministically without relying on __del__ / gc.collect().
+
+    WARNING: ModelPatcher.clone() shares the underlying model object.
+    Calling this on a clone will corrupt all other clones sharing the
+    same model. Only use when the model is not shared (e.g. FSDP path
+    where there is no cached_base_model).
     """
     model = getattr(model_patcher, "model", None)
     if model is None:

--- a/src/raylight/comfy_dist/model_patcher.py
+++ b/src/raylight/comfy_dist/model_patcher.py
@@ -77,6 +77,46 @@ def _safe_free_storage(tensor: torch.Tensor) -> None:
         raise
 
 
+def free_model_vram(model_patcher) -> None:
+    """Eagerly free GPU storage from a non-FSDP ModelPatcher.
+
+    Unlike model.detach(), this does NOT copy weights to CPU RAM.
+    Call before dropping the model reference so VRAM is released
+    deterministically without relying on __del__ / gc.collect().
+    """
+    model = getattr(model_patcher, "model", None)
+    if model is None:
+        return
+    # Break reference cycle (model.current_patcher -> model_patcher -> model)
+    # so __del__ -> detach(unpatch_all=False) won't re-copy to CPU.
+    if hasattr(model, "current_patcher"):
+        model.current_patcher = None
+
+    for m in model.modules():
+        for p in m.parameters(recurse=False):
+            try:
+                tensor = p.data
+                if not isinstance(tensor, torch.Tensor):
+                    continue
+                if tensor.device.type == "meta":
+                    continue
+                if _is_quantized_tensor_like(tensor):
+                    continue
+                _safe_free_storage(tensor)
+            except Exception:
+                continue
+        for b in m.buffers(recurse=False):
+            try:
+                tensor = b.data
+                if not isinstance(tensor, torch.Tensor):
+                    continue
+                if tensor.device.type == "meta":
+                    continue
+                _safe_free_storage(tensor)
+            except Exception:
+                continue
+
+
 def _is_quantized_tensor_like(tensor: torch.Tensor) -> bool:
     if not isinstance(tensor, torch.Tensor):
         return False

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -177,12 +177,19 @@ class RayWorker:
                     self.model.free_fsdp_vram()
                 except Exception as e:
                     print(f"[Rank {self.local_rank}] free_fsdp_vram failed in _reset_active_model: {e}")
-            else:
-                from raylight.comfy_dist.model_patcher import free_model_vram
                 try:
-                    free_model_vram(self.model)
+                    self.model.detach()
                 except Exception as e:
-                    print(f"[Rank {self.local_rank}] free_model_vram failed in _reset_active_model: {e}")
+                    print(f"[Rank {self.local_rank}] model.detach() failed in _reset_active_model: {e}")
+            else:
+                # Non-FSDP: unpatch LoRA weights but do NOT move model to CPU.
+                # clone() shares the underlying model with cached_base_model,
+                # so free_model_vram() would corrupt the cache. Instead, restore
+                # original weights from backup (device_to=None skips .to(CPU)).
+                try:
+                    self.model.unpatch_model(device_to=None)
+                except Exception as e:
+                    print(f"[Rank {self.local_rank}] model.unpatch_model() failed in _reset_active_model: {e}")
             try:
                 self.model.cleanup()
             except Exception as e:
@@ -614,13 +621,19 @@ class RayWorker:
 
         if hasattr(self.model, "free_fsdp_vram"):
             self.model.free_fsdp_vram()
+            try:
+                self.model.cleanup()
+            except Exception:
+                pass
         else:
-            from raylight.comfy_dist.model_patcher import free_model_vram
-            free_model_vram(self.model)
-        try:
-            self.model.cleanup()
-        except Exception:
-            pass
+            try:
+                self.model.unpatch_model(device_to=None)
+            except Exception:
+                pass
+            try:
+                self.model.cleanup()
+            except Exception:
+                pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return out
@@ -698,13 +711,19 @@ class RayWorker:
 
         if hasattr(self.model, "free_fsdp_vram"):
             self.model.free_fsdp_vram()
+            try:
+                self.model.cleanup()
+            except Exception:
+                pass
         else:
-            from raylight.comfy_dist.model_patcher import free_model_vram
-            free_model_vram(self.model)
-        try:
-            self.model.cleanup()
-        except Exception:
-            pass
+            try:
+                self.model.unpatch_model(device_to=None)
+            except Exception:
+                pass
+            try:
+                self.model.cleanup()
+            except Exception:
+                pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return (out,)

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -387,8 +387,28 @@ class RayWorker:
                 return
 
             if self.cached_base_model is not None and self.cached_base_key == base_key:
-                self._activate_cached_base_model(active_key)
-                return
+                # If cached model has GPU weights (from a previous full-load run
+                # without LoRA), free them now. Otherwise partially_load() sees
+                # model_loaded_weight_memory=0 and does a full_load=True pass that
+                # converts fp8 weights to bf16 during LoRA patching, spiking VRAM
+                # from ~15Gb to ~23Gb on each GPU.
+                _cached_has_gpu_weights = False
+                try:
+                    _first_p = next(self.cached_base_model.model.parameters(), None)
+                    if _first_p is not None and _first_p.device.type == "cuda":
+                        _cached_has_gpu_weights = True
+                except Exception:
+                    pass
+
+                if _cached_has_gpu_weights:
+                    from raylight.comfy_dist.model_patcher import free_model_vram
+
+                    free_model_vram(self.cached_base_model)
+                    self._invalidate_non_fsdp_cache()
+                    # Fall through to reload from disk (mmap, no RAM spike)
+                else:
+                    self._activate_cached_base_model(active_key)
+                    return
 
             self._reset_active_model()
             self._invalidate_non_fsdp_cache()
@@ -621,19 +641,10 @@ class RayWorker:
 
         if hasattr(self.model, "free_fsdp_vram"):
             self.model.free_fsdp_vram()
-            try:
-                self.model.cleanup()
-            except Exception:
-                pass
-        else:
-            try:
-                self.model.unpatch_model(device_to=None)
-            except Exception:
-                pass
-            try:
-                self.model.cleanup()
-            except Exception:
-                pass
+        try:
+            self.model.cleanup()
+        except Exception:
+            pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return out
@@ -711,19 +722,10 @@ class RayWorker:
 
         if hasattr(self.model, "free_fsdp_vram"):
             self.model.free_fsdp_vram()
-            try:
-                self.model.cleanup()
-            except Exception:
-                pass
-        else:
-            try:
-                self.model.unpatch_model(device_to=None)
-            except Exception:
-                pass
-            try:
-                self.model.cleanup()
-            except Exception:
-                pass
+        try:
+            self.model.cleanup()
+        except Exception:
+            pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return (out,)

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -172,20 +172,27 @@ class RayWorker:
         import comfy.model_management as comfy_model_management
 
         if self.model is not None:
-            try:
-                self.model.detach()
-            except Exception:
-                pass
+            if hasattr(self.model, "free_fsdp_vram"):
+                try:
+                    self.model.free_fsdp_vram()
+                except Exception as e:
+                    print(f"[Rank {self.local_rank}] free_fsdp_vram failed in _reset_active_model: {e}")
+            else:
+                from raylight.comfy_dist.model_patcher import free_model_vram
+                try:
+                    free_model_vram(self.model)
+                except Exception as e:
+                    print(f"[Rank {self.local_rank}] free_model_vram failed in _reset_active_model: {e}")
             try:
                 self.model.cleanup()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"[Rank {self.local_rank}] model.cleanup() failed in _reset_active_model: {e}")
 
         self.model = None
         self.overwrite_cast_dtype = None
         self.active_request_key = None
-        comfy_model_management.soft_empty_cache()
         gc.collect()
+        comfy_model_management.soft_empty_cache()
 
     def _invalidate_non_fsdp_cache(self):
         self.cached_base_model = None
@@ -605,10 +612,15 @@ class RayWorker:
             out = latent.copy()
             out["samples"] = samples
 
-        if ray.get_runtime_context().get_accelerator_ids()["GPU"][0] and self.parallel_dict["is_fsdp"] == "0":
-            self.model.detach()
+        if hasattr(self.model, "free_fsdp_vram"):
+            self.model.free_fsdp_vram()
         else:
-            self.model.detach()
+            from raylight.comfy_dist.model_patcher import free_model_vram
+            free_model_vram(self.model)
+        try:
+            self.model.cleanup()
+        except Exception:
+            pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return out
@@ -684,12 +696,15 @@ class RayWorker:
             out = latent.copy()
             out["samples"] = samples
 
-        if ray.get_runtime_context().get_accelerator_ids()["GPU"][0] and self.parallel_dict["is_fsdp"] == "0":
-            self.model.detach()
-
-        # I haven't implemented for non FSDP detached, so all rank model will be move into RAM
+        if hasattr(self.model, "free_fsdp_vram"):
+            self.model.free_fsdp_vram()
         else:
-            self.model.detach()
+            from raylight.comfy_dist.model_patcher import free_model_vram
+            free_model_vram(self.model)
+        try:
+            self.model.cleanup()
+        except Exception:
+            pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
         return (out,)


### PR DESCRIPTION
## Summary

Fix two VRAM/RAM issues in the non-FSDP RayWorker path that caused OOM crashes.

**Problem 1: VRAM spike (15Gb → 23Gb) on No LoRA → LoRA transition**

When a model was loaded without LoRA and kept in GPU VRAM after sampling, enabling LoRA on the next run caused ComfyUI's `partially_load()` to see `model_loaded_weight_memory=0` (stale accounting) and perform a `full_load=True` pass. This triggered `patch_weight_to_device()` which converted fp8 weights to bf16 during LoRA patching, adding ~7Gb per GPU and pushing 24Gb RTX 3090s into swap-to-RAM.

Fix: Detect when the cached base model still has GPU weights, free them with `free_model_vram()` (no CPU copy), invalidate the cache, and reload from disk via mmap. Mmap reload is fast and avoids any RAM spike.

**Problem 2: Model unloaded to CPU RAM after every sampling run**

Post-sampling called `model.detach()` unconditionally, which copies all weights to CPU RAM via `unpatch_model(offload_device)`. With 4 GPUs each holding a ~15Gb model, this consumed ~60Gb of system RAM — enough to OOM a 64Gb machine.

Fix: Replace `detach()` with `cleanup()` only. The model stays loaded in GPU VRAM between runs. FSDP models continue to call `free_fsdp_vram()` (#76). On model/LoRA change, `_reset_active_model()` handles unloading.

## Changes

- **`_reset_active_model()`**: Use `unpatch_model(device_to=None)` for non-FSDP models (restores backup weights without explicit CPU copy). FSDP path uses `free_fsdp_vram()` + `detach()`.
- **`load_unet()` cache hit**: Detect GPU-resident cached weights, free them, invalidate cache, fall through to mmap reload.
- **`custom_sampler()` / `common_ksampler()` post-sampling**: Remove `detach()`, use `cleanup()` only. Model stays in VRAM.

## Tests done with single fp8 model (that fits on 24GB GPU) wan2.2 high noise + 4step lora, with `FSDP=false`

- [x] No LoRA → No LoRA: model retained in VRAM, fast reuse
- [x] No LoRA → LoRA: no VRAM spike, mmap reload + LoRA patch
- [x] LoRA → LoRA: model retained with LoRA, fast reuse
- [x] LoRA → No LoRA: model reloaded clean, no RAM spike
- [x] Tested with `ulysses_degree=4` (4 GPUs)
- [x] Tested with `ulysses_degree=0` (separate sampler mode)