### PR TITLE
fix: don't free FSDP shard storage after sampling when model may be r…

### DIFF
--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -657,8 +657,6 @@ class RayWorker:
             out = latent.copy()
             out["samples"] = samples
 
-        if hasattr(self.model, "free_fsdp_vram"):
-            self.model.free_fsdp_vram()
         try:
             self.model.cleanup()
         except Exception:
@@ -738,8 +736,6 @@ class RayWorker:
             out = latent.copy()
             out["samples"] = samples
 
-        if hasattr(self.model, "free_fsdp_vram"):
-            self.model.free_fsdp_vram()
         try:
             self.model.cleanup()
         except Exception:


### PR DESCRIPTION
@komikndr after merging both PRs there was a bug introduced with FSDP VRAM cleanup - this PR is to fix it.

---
fix: don't free FSDP shard storage after sampling when model may be reused

free_fsdp_vram() in custom_sampler/common_ksampler freed DTensor shard
storage via _free_storage after every sampling run. But the fast path in
load_unet() reuses the same FSDP-wrapped model when active_request_key
matches. On the next run, patch_fsdp() skips (already wrapped), and the
forward pass all-gathers from freed (size-0) shard storage, causing
CUDA illegal memory access.

Remove post-sampling free_fsdp_vram() calls — VRAM is still freed when
the model actually changes (load_unet, _reset_active_model) or via
__del__ during garbage collection.