### PR TITLE
Unified Parallism Combine DP and USP

### DIFF
--- a/src/raylight/comfy_dist/model_patcher.py
+++ b/src/raylight/comfy_dist/model_patcher.py
@@ -152,6 +152,10 @@ def _get_parent_module_and_name(model: torch.nn.Module, param_name: str) -> tupl
     return model.get_submodule(parent_name), leaf_name
 
 
+def _unwrap_base_model(model):
+    return getattr(model, "model", model)
+
+
 def _promote_nonfloating_params_to_meta(model: torch.nn.Module, target_dtype: torch.dtype) -> int:
     replaced = 0
     for name, param in list(model.named_parameters()):
@@ -184,7 +188,8 @@ def patch_fsdp(self):
     use_quant_loader = has_qt_runtime or has_quant_sd
 
     if use_quant_loader:
-        placeholder_dtype = getattr(self.model.model, "manual_cast_dtype", None) or torch.bfloat16
+        base_model = _unwrap_base_model(self.model)
+        placeholder_dtype = getattr(base_model, "manual_cast_dtype", None) or torch.bfloat16
         replaced = _promote_nonfloating_params_to_meta(diffusion_model, placeholder_dtype)
         if replaced > 0:
             print(f"[Rank {self.rank}] Promoted {replaced} non-floating quant params to meta placeholders before FSDP wrapping")

--- a/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
+++ b/src/raylight/comfy_extra_dist/nodes_custom_sampler.py
@@ -13,6 +13,33 @@ from .ray_patch_decorator import ray_patch_with_return
 from raylight.distributed_worker.utils import Noise_EmptyNoise, Noise_RandomNoise
 
 
+def _normalize_grouped_inputs(values: list, expected_length: int, label: str):
+    if len(values) == expected_length:
+        return values
+    if len(values) == 1:
+        return values * expected_length
+    if len(values) > expected_length:
+        return values[:expected_length]
+    raise ValueError(f"{label} must provide 1 item or at least {expected_length} items, got {len(values)}")
+
+
+def _collect_grouped_results(results: list, expected_length: int, label: str):
+    grouped_results = {}
+    for result in results:
+        if result is None:
+            continue
+        dp_rank = int(result["dp_rank"])
+        if dp_rank in grouped_results:
+            raise RuntimeError(f"{label} produced multiple outputs for dp_rank {dp_rank}")
+        grouped_results[dp_rank] = result["result"]
+
+    missing = [dp_rank for dp_rank in range(expected_length) if dp_rank not in grouped_results]
+    if missing:
+        raise RuntimeError(f"{label} missing outputs for dp_rank {missing}")
+
+    return [grouped_results[dp_rank] for dp_rank in range(expected_length)]
+
+
 class RayBasicScheduler:
     @classmethod
     def INPUT_TYPES(s):
@@ -279,6 +306,89 @@ class XFuserSamplerCustom:
         return (out, ray_actors)
 
 
+class UnifiedParallelSamplerCustom:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "ray_actors": ("RAY_ACTORS",),
+                "add_noise": ("BOOLEAN", {"default": True}),
+                "noise_list": ("NOISE",),
+                "cfg": (
+                    "FLOAT",
+                    {
+                        "default": 8.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.1,
+                        "round": 0.01,
+                    },
+                ),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "sampler": ("SAMPLER",),
+                "sigmas": ("SIGMAS",),
+                "latent_image": ("LATENT",),
+            }
+        }
+
+    RETURN_TYPES = ("LATENT", "RAY_ACTORS")
+    RETURN_NAMES = ("latent", "ray_actors")
+    OUTPUT_IS_LIST = (True, False)
+    INPUT_IS_LIST = True
+
+    FUNCTION = "ray_sample"
+
+    CATEGORY = "Raylight/extra/custom_sampling/samplers"
+
+    def ray_sample(
+        self,
+        ray_actors,
+        add_noise,
+        noise_list,
+        cfg,
+        positive,
+        negative,
+        sampler,
+        sigmas,
+        latent_image,
+    ):
+        ray_actors = ray_actors[0]
+        add_noise = add_noise[0]
+        cfg = cfg[0]
+        sampler = sampler[0]
+        sigmas = sigmas[0]
+
+        gc.collect()
+        comfy.model_management.unload_all_models()
+        comfy.model_management.soft_empty_cache()
+        gpu_actors = ray_actors["workers"]
+        group_infos = ray.get([actor.get_exec_group_info.remote() for actor in gpu_actors])
+        dp_degree = int(group_infos[0]["dp_degree"])
+        noise_list = _normalize_grouped_inputs(noise_list, dp_degree, "noise_list")
+        positive = _normalize_grouped_inputs(positive, dp_degree, "positive")
+        negative = _normalize_grouped_inputs(negative, dp_degree, "negative")
+        latent_image = _normalize_grouped_inputs(latent_image, dp_degree, "latent_image")
+
+        futures = [
+            actor.custom_sampler.remote(
+                add_noise,
+                noise_list[group_info["dp_rank"]],
+                cfg,
+                positive[group_info["dp_rank"]],
+                negative[group_info["dp_rank"]],
+                sampler,
+                sigmas,
+                latent_image[group_info["dp_rank"]],
+                grouped_output=True,
+            )
+            for actor, group_info in zip(gpu_actors, group_infos)
+        ]
+        results = ray.get(futures)
+        out = _collect_grouped_results(results, dp_degree, "Unified Parallel SamplerCustom")
+        return (out, ray_actors)
+
+
 class DPSamplerCustom:
     @classmethod
     def INPUT_TYPES(s):
@@ -421,6 +531,7 @@ class RayAddNoise:
 
 NODE_CLASS_MAPPINGS = {
     "XFuserSamplerCustom": XFuserSamplerCustom,
+    "UnifiedParallelSamplerCustom": UnifiedParallelSamplerCustom,
     "DPSamplerCustom": DPSamplerCustom,
     "RayBasicScheduler": RayBasicScheduler,
     "RayBetaSamplingScheduler": RayBetaSamplingScheduler,
@@ -431,5 +542,6 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "XFuserSamplerCustom": "XFuser SamplerCustom",
+    "UnifiedParallelSamplerCustom": "Unified Parallel SamplerCustom (Advance)",
     "DPSamplerCustom": "Data Parallel SamplerCustom",
 }

--- a/src/raylight/distributed_worker/parallel_group_manager.py
+++ b/src/raylight/distributed_worker/parallel_group_manager.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 import raylight.distributed_modules.attention as xfuser_attn
 
 from xfuser.core.distributed import (
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_data_parallel_rank,
+    get_data_parallel_world_size,
     get_pipeline_parallel_rank,
     get_pipeline_parallel_world_size,
     get_pp_group,
@@ -61,6 +65,10 @@ class XFuserParallelContext:
     rank_generator: RankGenerator
     global_rank: int
     global_world_size: int
+    data_parallel_rank: int
+    data_parallel_world_size: int
+    cfg_rank: int
+    cfg_world_size: int
     pipeline_rank: int
     pipeline_world_size: int
     sequence_rank: int
@@ -91,12 +99,20 @@ def initialize_xfuser_parallel(local_rank: int, world_size: int, parallel_dict: 
             "pp_degree * ulysses_degree * ring_degree * cfg_degree: "
             f"{world_size} is not divisible by {base_config.pp_degree} * {base_config.ulysses_degree} * {base_config.ring_degree} * {base_config.cfg_degree}"
         )
+    derived_data_parallel_degree = world_size // base_config.model_parallel_size
+    requested_data_parallel_degree = int(parallel_dict.get("dp_degree", 0) or 0)
+    if requested_data_parallel_degree not in (0, derived_data_parallel_degree):
+        raise ValueError(
+            "Ray worker count must equal "
+            "dp_degree * pp_degree * ulysses_degree * ring_degree * cfg_degree: "
+            f"{world_size} != {requested_data_parallel_degree} * {base_config.pp_degree} * {base_config.ulysses_degree} * {base_config.ring_degree} * {base_config.cfg_degree}"
+        )
     config = XFuserParallelConfig(
         ulysses_degree=base_config.ulysses_degree,
         ring_degree=base_config.ring_degree,
         cfg_degree=base_config.cfg_degree,
         pp_degree=base_config.pp_degree,
-        data_parallel_degree=world_size // base_config.model_parallel_size,
+        data_parallel_degree=derived_data_parallel_degree,
     )
 
     if parallel_dict.get("is_xdit"):
@@ -126,6 +142,10 @@ def initialize_xfuser_parallel(local_rank: int, world_size: int, parallel_dict: 
         rank_generator=rank_generator,
         global_rank=local_rank,
         global_world_size=world_size,
+        data_parallel_rank=get_data_parallel_rank(),
+        data_parallel_world_size=get_data_parallel_world_size(),
+        cfg_rank=get_classifier_free_guidance_rank(),
+        cfg_world_size=get_classifier_free_guidance_world_size(),
         pipeline_rank=get_pipeline_parallel_rank(),
         pipeline_world_size=get_pipeline_parallel_world_size(),
         sequence_rank=get_sequence_parallel_rank(),

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -232,6 +232,35 @@ class RayWorker:
     def get_parallel_dict(self):
         return self.parallel_dict
 
+    def get_exec_group_info(self):
+        if self.xfuser_parallel is None:
+            return {
+                "global_rank": self.local_rank,
+                "dp_rank": 0,
+                "dp_degree": 1,
+                "is_group_leader": self.local_rank == 0,
+            }
+
+        is_group_leader = (
+            self.xfuser_parallel.sequence_rank == 0 and self.xfuser_parallel.pipeline_rank == 0 and self.xfuser_parallel.cfg_rank == 0
+        )
+        return {
+            "global_rank": self.xfuser_parallel.global_rank,
+            "dp_rank": self.xfuser_parallel.data_parallel_rank,
+            "dp_degree": self.xfuser_parallel.data_parallel_world_size,
+            "is_group_leader": is_group_leader,
+        }
+
+    def _grouped_sampling_result(self, result):
+        group_info = self.get_exec_group_info()
+        if not group_info["is_group_leader"]:
+            return None
+
+        return {
+            "dp_rank": group_info["dp_rank"],
+            "result": result,
+        }
+
     def set_parallel_dict(self, parallel_dict):
         self.parallel_dict = parallel_dict
         self.pipefusion_config = PipeFusionConfig.from_parallel_dict(self.parallel_dict)
@@ -345,7 +374,6 @@ class RayWorker:
                     self.model.free_fsdp_vram()
                 except Exception as e:
                     print(f"[Rank {self.local_rank}] free_fsdp_vram failed: {e}")
-
 
             # Monkey patch
             import comfy.model_patcher as model_patcher
@@ -560,7 +588,7 @@ class RayWorker:
         vae_model.throw_exception_if_invalid()
 
         import types
-        
+
         vae_model.decode_tiled_1d = types.MethodType(decode_tiled_1d, vae_model)
         vae_model.decode_tiled_ = types.MethodType(decode_tiled_, vae_model)
         vae_model.decode_tiled_3d = types.MethodType(decode_tiled_3d, vae_model)
@@ -685,6 +713,7 @@ class RayWorker:
         start_step=None,
         last_step=None,
         force_full_denoise=False,
+        grouped_output=False,
     ):
         import comfy.model_management as comfy_model_management
         import comfy.sample as comfy_sample
@@ -744,6 +773,8 @@ class RayWorker:
             pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
+        if grouped_output:
+            return self._grouped_sampling_result(out)
         return (out,)
 
 

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -43,6 +43,8 @@ from ray.exceptions import RayActorError
 # If ray actor function being called from outside, ray.get([task in actor task]) will become sync between rank
 # If called from ray actor within. dist.barrier() become the sync.
 
+# PIPEFUSION STUFF IS ONLY TESTING, IT IS BREAKING DOWN ALLLL THE TIME
+
 
 # Comfy cli args, does not get pass through into ray actor
 def patch_enable_comfy_kitchen_fsdp(fn):
@@ -98,9 +100,10 @@ class RayWorker:
             # device_id=self.device
         )
 
-        # (TODO-Komikndr) Should be modified so it can do support DP on top of FSDP
         if self.parallel_dict["is_xdit"] or self.parallel_dict["is_fsdp"]:
             self.device_mesh = dist.device_mesh.init_device_mesh("cuda", mesh_shape=(self.global_world_size,))
+
+        # Just experimenting, user can't trigger this
         elif not self.parallel_dict.get("pipefusion_enabled"):
             print(f"Running Ray in normal seperate sampler with: {self.global_world_size} number of workers")
 
@@ -638,6 +641,7 @@ class RayWorker:
         sampler,
         sigmas,
         latent_image,
+        grouped_output=False,
     ):
         import comfy.model_management as comfy_model_management
         import comfy.sample as comfy_sample
@@ -693,6 +697,8 @@ class RayWorker:
             pass
         comfy_model_management.soft_empty_cache()
         gc.collect()
+        if grouped_output:
+            return self._grouped_sampling_result(out)
         return out
 
     @patch_temp_fix_ck_ops

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -127,14 +127,16 @@ class RayWorker:
             )
 
     def get_meta_model(self):
-        first_param_device = next(self.model.model.parameters()).device
+        base_model = getattr(self.model, "model", self.model)
+        first_param_device = next(base_model.parameters()).device
         if first_param_device == torch.device("meta"):
             return self.model
         else:
             raise ValueError("Model recieved is not meta, can cause OOM in large model")
 
     def set_meta_model(self, model):
-        first_param_device = next(model.model.parameters()).device
+        base_model = getattr(model, "model", model)
+        first_param_device = next(base_model.parameters()).device
         if first_param_device == torch.device("meta"):
             self.state_dict = None
             self.model = model
@@ -216,7 +218,8 @@ class RayWorker:
         if self.lora_list is not None:
             self.load_lora()
 
-        self.overwrite_cast_dtype = self.model.model.manual_cast_dtype
+        base_model = getattr(self.model, "model", self.model)
+        self.overwrite_cast_dtype = getattr(base_model, "manual_cast_dtype", None)
         self.active_request_key = active_key
         self.is_model_loaded = True
 
@@ -303,7 +306,7 @@ class RayWorker:
                 "PipeFusion topology is now initialized through xFuser, but the Wan execution path does not yet combine PP with USP"
             )
 
-        base_model = self.model.model
+        base_model = getattr(self.model, "model", self.model)
         if not hasattr(base_model, "diffusion_model") or not hasattr(base_model.diffusion_model, "blocks"):
             raise ValueError(f"PipeFusion requires a Wan diffusion model with blocks, got {type(base_model).__name__}")
 
@@ -367,7 +370,8 @@ class RayWorker:
 
             # Fast path: same base model + same LoRA — reuse FSDP-wrapped model
             if self.model is not None and self.active_request_key == active_key:
-                self.overwrite_cast_dtype = self.model.model.manual_cast_dtype
+                base_model = getattr(self.model, "model", self.model)
+                self.overwrite_cast_dtype = getattr(base_model, "manual_cast_dtype", None)
                 self.is_model_loaded = True
                 return
 
@@ -415,7 +419,8 @@ class RayWorker:
             if self.lora_list is not None:
                 self.load_lora()
 
-            self.overwrite_cast_dtype = self.model.model.manual_cast_dtype
+            base_model = getattr(self.model, "model", self.model)
+            self.overwrite_cast_dtype = getattr(base_model, "manual_cast_dtype", None)
             self.is_model_loaded = True
             self.active_request_key = active_key
             return
@@ -431,7 +436,8 @@ class RayWorker:
             )
 
             if self.model is not None and self.active_request_key == active_key:
-                self.overwrite_cast_dtype = self.model.model.manual_cast_dtype
+                base_model = getattr(self.model, "model", self.model)
+                self.overwrite_cast_dtype = getattr(base_model, "manual_cast_dtype", None)
                 self.is_model_loaded = True
                 return
 
@@ -443,7 +449,8 @@ class RayWorker:
                 # from ~15Gb to ~23Gb on each GPU.
                 _cached_has_gpu_weights = False
                 try:
-                    _first_p = next(self.cached_base_model.model.parameters(), None)
+                    cached_base_model = getattr(self.cached_base_model, "model", self.cached_base_model)
+                    _first_p = next(cached_base_model.parameters(), None)
                     if _first_p is not None and _first_p.device.type == "cuda":
                         _cached_has_gpu_weights = True
                 except Exception:

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -283,9 +283,9 @@ class RayInitializer:
                 "dp_degree": (
                     "INT",
                     {
-                        "default": 0,
+                        "default": 1,
                         "min": 0,
-                        "tooltip": "Data-parallel degree. Leave 0 to auto use the remaining GPUs after ulysses/ring/cfg.",
+                        "tooltip": "Data-parallel degree. Just use 1 or leave 0 when using Unified Parallel Sampler to auto use the remaining GPUs after ulysses/ring/cfg.",
                     },
                 ),
                 "sync_ulysses": (
@@ -530,9 +530,9 @@ class RayInitializerAdvanced(RayInitializer):
                 "dp_degree": (
                     "INT",
                     {
-                        "default": 0,
+                        "default": 1,
                         "min": 0,
-                        "tooltip": "Data-parallel degree. Leave 0 to auto use the remaining GPUs after ulysses/ring/cfg.",
+                        "tooltip": "Data-parallel degree. Default 1 keeps the legacy layout. Leave 0 when using Unified Parallel Sampler to auto use the remaining GPUs after ulysses/ring/cfg.",
                     },
                 ),
                 "sync_ulysses": (
@@ -1346,7 +1346,7 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "XFuserKSamplerAdvanced": "XFuser KSampler (Advanced)",
-    "UnifiedParallelSampler": "Unified Parallel Sampler",
+    "UnifiedParallelSampler": "Unified Parallel Sampler (Advance)",
     "DPKSamplerAdvanced": "Data Parallel KSampler (Advanced)",
     "RayKill": "Kill Ray",
     "RayUNETLoader": "Load Diffusion Model (Ray)",

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -171,6 +171,33 @@ def _effective_parallel_degree(value: int | None) -> int:
     return 1 if value <= 0 else value
 
 
+def _normalize_grouped_inputs(values: list, expected_length: int, label: str):
+    if len(values) == expected_length:
+        return values
+    if len(values) == 1:
+        return values * expected_length
+    if len(values) > expected_length:
+        return values[:expected_length]
+    raise ValueError(f"{label} must provide 1 item or at least {expected_length} items, got {len(values)}")
+
+
+def _collect_grouped_results(results: list, expected_length: int, label: str):
+    grouped_results = {}
+    for result in results:
+        if result is None:
+            continue
+        dp_rank = int(result["dp_rank"])
+        if dp_rank in grouped_results:
+            raise RuntimeError(f"{label} produced multiple outputs for dp_rank {dp_rank}")
+        grouped_results[dp_rank] = result["result"]
+
+    missing = [dp_rank for dp_rank in range(expected_length) if dp_rank not in grouped_results]
+    if missing:
+        raise RuntimeError(f"{label} missing outputs for dp_rank {missing}")
+
+    return [grouped_results[dp_rank] for dp_rank in range(expected_length)]
+
+
 def _reset_pipefusion_runtime_config(parallel_dict: dict[str, Any]):
     parallel_dict["pipefusion_enabled"] = False
     parallel_dict["num_pipeline_patch"] = 1
@@ -253,6 +280,14 @@ class RayInitializer:
                     "INT",
                     {"default": 1, "tooltip": "CFG parallel degree. `2` splits conditional and unconditional passes across GPUs."},
                 ),
+                "dp_degree": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "tooltip": "Data-parallel degree. Leave 0 to auto use the remaining GPUs after ulysses/ring/cfg.",
+                    },
+                ),
                 "sync_ulysses": (
                     "BOOLEAN",
                     {
@@ -300,6 +335,7 @@ class RayInitializer:
         ulysses_degree: int,
         ring_degree: int,
         cfg_degree: int,
+        dp_degree: int,
         sync_ulysses: bool,
         FSDP: bool,
         FSDP_CPU_OFFLOAD: bool,
@@ -346,6 +382,8 @@ class RayInitializer:
             raise ValueError(f"ERROR, num_gpus: {world_size}, is lower than {ulysses_degree=} x {ring_degree=} x {cfg_degree=}")
         if cfg_degree > 2:
             raise ValueError("CFG batch only can be divided into 2 degree of parallelism, since its dimension is only 2")
+        if dp_degree < 0:
+            raise ValueError("dp_degree cannot be negative")
 
         self.parallel_dict["is_xdit"] = False
         self.parallel_dict["is_fsdp"] = False
@@ -353,19 +391,34 @@ class RayInitializer:
         self.parallel_dict["global_world_size"] = world_size
         self.parallel_dict["use_mmap"] = use_mmap
         self.parallel_dict["pp_degree"] = 1
+        self.parallel_dict["dp_degree"] = 1
         _reset_pipefusion_runtime_config(self.parallel_dict)
 
         if ulysses_degree > 0 or ring_degree > 0 or cfg_degree > 0:
-            if ulysses_degree * ring_degree * cfg_degree == 0:
+            model_parallel_size = ulysses_degree * ring_degree * cfg_degree
+            if model_parallel_size == 0:
                 raise ValueError(f"""ERROR, parallel product of {ulysses_degree=} x {ring_degree=} x {cfg_degree=} is 0.
                  Please make sure to set any parallel degree to be greater than 0,
                  or switch into DPKSampler and set 0 to all parallel degree""")
+            if world_size % model_parallel_size != 0:
+                raise ValueError(
+                    "GPU count must be divisible by ulysses_degree x ring_degree x cfg_degree: "
+                    f"{world_size} is not divisible by {ulysses_degree} x {ring_degree} x {cfg_degree}"
+                )
+            auto_dp_degree = world_size // model_parallel_size
+            effective_dp_degree = auto_dp_degree if dp_degree == 0 else dp_degree
+            if world_size != model_parallel_size * effective_dp_degree:
+                raise ValueError(
+                    "GPU count must equal dp_degree x ulysses_degree x ring_degree x cfg_degree: "
+                    f"{world_size} != {effective_dp_degree} x {ulysses_degree} x {ring_degree} x {cfg_degree}"
+                )
             self.parallel_dict["attention"] = XFuser_attention
             self.parallel_dict["is_xdit"] = True
             self.parallel_dict["ulysses_degree"] = ulysses_degree
             self.parallel_dict["ring_degree"] = ring_degree
             self.parallel_dict["cfg_degree"] = cfg_degree
             self.parallel_dict["sync_ulysses"] = sync_ulysses
+            self.parallel_dict["dp_degree"] = effective_dp_degree
 
         if FSDP:
             self.parallel_dict["fsdp_cpu_offload"] = FSDP_CPU_OFFLOAD
@@ -473,6 +526,14 @@ class RayInitializerAdvanced(RayInitializer):
                 "cfg_degree": (
                     "INT",
                     {"default": 1, "tooltip": "CFG parallel degree. `2` splits conditional and unconditional passes across GPUs."},
+                ),
+                "dp_degree": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "tooltip": "Data-parallel degree. Leave 0 to auto use the remaining GPUs after ulysses/ring/cfg.",
+                    },
                 ),
                 "sync_ulysses": (
                     "BOOLEAN",
@@ -861,6 +922,121 @@ class XFuserKSamplerAdvanced:
         return (results[0][0], ray_actors)
 
 
+class UnifiedParallelSampler:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "add_noise": (["enable", "disable"],),
+                "noise_list": (
+                    "NOISE",
+                    {
+                        "tooltip": "List of noise seeds for each xFuser data-parallel group. Use one item to share the same seed across all groups."
+                    },
+                ),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
+                "cfg": (
+                    "FLOAT",
+                    {
+                        "default": 8.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.1,
+                        "round": 0.01,
+                    },
+                ),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS,),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS,),
+                "ray_actors": (
+                    "RAY_ACTORS",
+                    {"tooltip": "Ray Actor to submit the model into"},
+                ),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "latent_image": ("LATENT",),
+                "start_at_step": ("INT", {"default": 0, "min": 0, "max": 10000}),
+                "end_at_step": ("INT", {"default": 10000, "min": 0, "max": 10000}),
+                "return_with_leftover_noise": (["disable", "enable"],),
+            }
+        }
+
+    RETURN_TYPES = ("LATENT", "RAY_ACTORS")
+    RETURN_NAMES = ("latent", "ray_actors")
+    OUTPUT_IS_LIST = (True, False)
+    INPUT_IS_LIST = True
+    FUNCTION = "ray_sample"
+
+    CATEGORY = "Raylight"
+
+    def ray_sample(
+        self,
+        ray_actors,
+        add_noise,
+        noise_list,
+        steps,
+        cfg,
+        sampler_name,
+        scheduler,
+        positive,
+        negative,
+        latent_image,
+        start_at_step,
+        end_at_step,
+        return_with_leftover_noise,
+        denoise=1.0,
+    ):
+        ray_actors = ray_actors[0]
+        add_noise = add_noise[0]
+        steps = steps[0]
+        cfg = cfg[0]
+        sampler_name = sampler_name[0]
+        scheduler = scheduler[0]
+        start_at_step = start_at_step[0]
+        end_at_step = end_at_step[0]
+        return_with_leftover_noise = return_with_leftover_noise[0]
+
+        gc.collect()
+        comfy.model_management.unload_all_models()
+        comfy.model_management.soft_empty_cache()
+        force_full_denoise = True
+        if return_with_leftover_noise == "enable":
+            force_full_denoise = False
+        disable_noise = False
+        if add_noise == "disable":
+            disable_noise = True
+
+        gpu_actors = ray_actors["workers"]
+        group_infos = ray.get([actor.get_exec_group_info.remote() for actor in gpu_actors])
+        dp_degree = int(group_infos[0]["dp_degree"])
+        noise_list = _normalize_grouped_inputs(noise_list, dp_degree, "noise_list")
+        positive = _normalize_grouped_inputs(positive, dp_degree, "positive")
+        negative = _normalize_grouped_inputs(negative, dp_degree, "negative")
+        latent_image = _normalize_grouped_inputs(latent_image, dp_degree, "latent_image")
+        futures = [
+            actor.common_ksampler.remote(
+                noise_list[group_info["dp_rank"]],
+                steps,
+                cfg,
+                sampler_name,
+                scheduler,
+                positive[group_info["dp_rank"]],
+                negative[group_info["dp_rank"]],
+                latent_image[group_info["dp_rank"]],
+                denoise=denoise,
+                disable_noise=disable_noise,
+                start_step=start_at_step,
+                last_step=end_at_step,
+                force_full_denoise=force_full_denoise,
+                grouped_output=True,
+            )
+            for actor, group_info in zip(gpu_actors, group_infos)
+        ]
+
+        results = ray.get(futures)
+        results = _collect_grouped_results(results, dp_degree, "Unified Parallel Sampler")
+        return (results, ray_actors)
+
+
 class DPKSamplerAdvanced:
     @classmethod
     def INPUT_TYPES(s):
@@ -1156,6 +1332,7 @@ class RayVAEDecodeDistributed:
 
 NODE_CLASS_MAPPINGS = {
     "XFuserKSamplerAdvanced": XFuserKSamplerAdvanced,
+    "UnifiedParallelSampler": UnifiedParallelSampler,
     "DPKSamplerAdvanced": DPKSamplerAdvanced,
     "RayKill": RayKill,
     "RayUNETLoader": RayUNETLoader,
@@ -1169,6 +1346,7 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "XFuserKSamplerAdvanced": "XFuser KSampler (Advanced)",
+    "UnifiedParallelSampler": "Unified Parallel Sampler",
     "DPKSamplerAdvanced": "Data Parallel KSampler (Advanced)",
     "RayKill": "Kill Ray",
     "RayUNETLoader": "Load Diffusion Model (Ray)",


### PR DESCRIPTION
This PR continues the effort to combine `DP` with `FSDP_REPLICA`, inspired by avtc’s idea:

https://github.com/komikndr/raylight/pull/80

The reason this is separate is that, sooner or later, someone will try to run DP on top of USP/CFG parallelism. I prefer not to lock this into `FSDP_REPLICA` specifically, so it can be generalized.

With this approach, you can run 4 GPUs as 2 DP x 2 USP, producing two outputs simultaneously while improving generation speed by around 1.6-1.9x, depending on comm.

This uses a new Unified Parallel Sampler for compatibility, so it does not break the current XFuser sampler. The XFuser sampler still assumes 1 DP and N degrees of other parallelism.

<img width="1436" height="727" alt="image" src="https://github.com/user-attachments/assets/8b144608-da84-42c1-bc38-69fc1329df58" />


Currently testing on a single 3090 as a sanity check. Next step is testing on 2× RTX 2000 Ada, and then 4× RTX 2000 Ada.