### PR TITLE
feat: add ControlNet support for distributed inference (USP + FSDP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Activate FSDP, and set the Ulysses degree to the number of GPUs. Use the XFuser 
 | Flux Kontext      | ✅  | ✅   | ❌  |
 | Flux Krea         | ✅  | ✅   | ❌  |
 | Flux 2            | ✅  | ✅   | ❌  |
-| Flux ControlNet   | ❌  | ❌   | ❌  |
+| Flux ControlNet   | ✅  | ✅   | ❌  |
 
 
 **Chroma**
@@ -208,14 +208,14 @@ Activate FSDP, and set the Ulysses degree to the number of GPUs. Use the XFuser 
 |-------------------|-----|------|-----|
 | Chroma            | ✅  | ✅   | ✅  |
 | Chroma Radiance   | ✅  | ✅   | ✅  |
-| Chroma ControlNet | ❌  | ❌   | ✅  |
+| Chroma ControlNet | ✅† | ✅†  | ✅  |
 
 
 **Qwen**
 | Model             | USP | FSDP | CFG |
 |-------------------|-----|------|-----|
 | Qwen Image/Edit   | ✅  | ✅   | ✅  |
-| ControlNet        | ❌  | ❌   | ✅  |
+| ControlNet        | ✅  | ✅   | ✅  |
 
 
 **Z Image, Lumina 2**
@@ -230,7 +230,7 @@ Activate FSDP, and set the Ulysses degree to the number of GPUs. Use the XFuser 
 |-------------------|-----|------|-----|
 | Hunyuan Video     | ✅  | ✅   | ❌  |
 | Hunyuan 1.5       | ✅  | ✅   | ❌  |
-| ControlNet        | ❌  | ❌   | ❌  |
+| ControlNet        | ✅† | ✅†  | ❌  |
 
 
 **Kandinsky5**
@@ -255,6 +255,7 @@ Activate FSDP, and set the Ulysses degree to the number of GPUs. Use the XFuser 
 **Legend:**
 - ✅ = Supported
 - ❌ = Not currently supported.
+- ✅† = Code-ready, awaiting ControlNet model weights.
 - T = Text
 - I = Image
 - A = Audio
@@ -264,6 +265,11 @@ Activate FSDP, and set the Ulysses degree to the number of GPUs. Use the XFuser 
 - Non standard Wan variant (Phantom, S2V, etc...) is not tested
 - CFG parallel for Flux, Hunyuan, is technically supported by Raylight,
   but since these models do not support conditional batches (CFG = 1), enabling it has no effect.
+- Chroma and Hunyuan Video ControlNet support is implemented in the USP/FSDP code paths
+  but no ControlNet model weights are currently available in ComfyUI to test with.
+- Only one ControlNet model per workflow is supported. To apply the same model with
+  different images or strengths, use multiple Apply ControlNet (Ray) nodes connected
+  to a single Load ControlNet (Ray) node.
 
 ## Attention
 

--- a/src/raylight/comfy_dist/fsdp_utils.py
+++ b/src/raylight/comfy_dist/fsdp_utils.py
@@ -265,13 +265,27 @@ def _materialize_missing_ignored_params(
             full_sd[param_name] = None
 
 
+def _collect_subtree_params(module: torch.nn.Module) -> set[torch.nn.Parameter]:
+    return set(module.parameters())
+
+
 def fully_shard_bottom_up(
     model: torch.nn.Module,
     fsdp_kwargs: dict[str, Any],
     native_ignore_scale: bool,
+    ignored_modules: set[torch.nn.Module] | None = None,
 ) -> int:
+    excluded_params: set[torch.nn.Parameter] = set()
+    if ignored_modules:
+        for mod in ignored_modules:
+            excluded_params |= _collect_subtree_params(mod)
+
+    shard_order = collect_bottom_up_shard_order(model)
+    if ignored_modules:
+        shard_order = [(n, m) for n, m in shard_order if m not in ignored_modules]
+
     num_layers_sharded = 0
-    for _name, module in collect_bottom_up_shard_order(model):
+    for _name, module in shard_order:
         kwargs = dict(fsdp_kwargs)
         ignored_params: set[torch.nn.Parameter] = set()
         if native_ignore_scale:
@@ -280,6 +294,9 @@ def fully_shard_bottom_up(
         ignored_params |= collect_input_scale_ignored_params(module)
         ignored_params |= collect_scalar_ignored_params(module)
         ignored_params |= collect_odd_dim0_ignored_params(module)
+
+        subtree_params = set(module.parameters())
+        ignored_params |= (excluded_params & subtree_params)
 
         if ignored_params:
             kwargs["ignored_params"] = ignored_params
@@ -290,6 +307,38 @@ def fully_shard_bottom_up(
     if num_layers_sharded == 0:
         raise ValueError("No layer modules were sharded. Please check if shard conditions are working as expected.")
     return num_layers_sharded
+
+
+def materialize_excluded_params(
+    model: torch.nn.Module,
+    excluded_modules: set[torch.nn.Module],
+    full_sd: dict[str, Any],
+    device: torch.device,
+    cpu_offload: bool = False,
+) -> int:
+    """Load parameters of modules excluded from FSDP wrapping from a full state dict.
+
+    After FSDP wrapping, excluded-module parameters remain on meta device.
+    This function materializes them onto *device* (or CPU when cpu_offload).
+    Returns the number of parameters materialized.
+    """
+    module_to_prefix: dict[int, str] = {}
+    for name, mod in model.named_modules():
+        module_to_prefix[id(mod)] = name
+
+    count = 0
+    for module in excluded_modules:
+        prefix = module_to_prefix.get(id(module), "")
+        for param_name, param in module.named_parameters(recurse=True):
+            full_name = f"{prefix}.{param_name}" if prefix else param_name
+            if not getattr(param, "is_meta", False):
+                continue
+            full_tensor = full_sd.get(full_name)
+            if full_tensor is None:
+                continue
+            _materialize_unsharded_param(model, full_name, param, full_tensor, device, cpu_offload)
+            count += 1
+    return count
 
 
 def _decode_comfy_quant(conf: Any) -> dict[str, Any] | None:

--- a/src/raylight/comfy_dist/model_patcher.py
+++ b/src/raylight/comfy_dist/model_patcher.py
@@ -6,6 +6,7 @@ import gc
 from typing import TYPE_CHECKING
 
 import torch
+import torch.distributed as dist
 from torch.distributed.fsdp import FSDPModule
 from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 from torch.distributed.utils import _free_storage
@@ -16,7 +17,7 @@ from comfy.patcher_extension import CallbacksMP
 from comfy.model_patcher import get_key_weight, string_to_seed, move_weight_functions
 
 from raylight import comfy_dist
-from .fsdp_utils import freeze_and_detect_qt, fully_shard_bottom_up, load_from_full_model_state_dict
+from .fsdp_utils import freeze_and_detect_qt, fully_shard_bottom_up, load_from_full_model_state_dict, materialize_excluded_params
 
 if TYPE_CHECKING:
     from raylight.distributed_worker.parallel_group_manager import XFuserParallelContext
@@ -167,6 +168,60 @@ def _promote_nonfloating_params_to_meta(model: torch.nn.Module, target_dtype: to
     return replaced
 
 
+def _pre_init_fsdp(diffusion_model: torch.nn.Module) -> None:
+    """Pre-initialize FSDP param groups so the root is always initialized first.
+
+    Without this, a ControlNet calling ``base_model.time_text_embed()`` directly
+    would trigger ``_lazy_init()`` on a *nested* FSDP unit instead of the root,
+    leaving some param groups with stale meta-device references.
+    """
+    from torch.distributed.fsdp._fully_shard._fsdp_state import (
+        _get_module_fsdp_state,
+        FSDPState,
+    )
+
+    root_state = _get_module_fsdp_state(diffusion_model)
+    if root_state is None or not isinstance(root_state, FSDPState):
+        return
+    if root_state._is_root is not None:
+        return  # already initialized
+
+    root_state._lazy_init()
+
+
+def _collect_controlnet_shared_modules(diffusion_model: torch.nn.Module) -> set[torch.nn.Module]:
+    """Collect base model sub-modules that ControlNet calls directly.
+
+    These modules must NOT be FSDP-wrapped because ControlNet invokes them
+    outside the base model's normal forward path.  If they were FSDP-wrapped,
+    each call would trigger an all_gather that only some ranks participate in,
+    causing an NCCL collective timeout.
+    """
+    # Modules called by ControlNet.forward() via base_model.* (getattr skips
+    # names that don't exist on a given architecture, so the union is safe).
+    #   QwenImage FunControlNet: process_img, pe_embedder, img_in, txt_norm,
+    #                             txt_in, time_text_embed
+    #   Flux ControlNet:          img_in, time_in, vector_in, guidance_in,
+    #                             txt_in, pe_embedder
+    _CONTROLNET_SHARED_NAMES = (
+        "process_img",
+        "pe_embedder",
+        "img_in",
+        "txt_norm",
+        "txt_in",
+        "time_text_embed",
+        "time_in",
+        "vector_in",
+        "guidance_in",
+    )
+    excluded: set[torch.nn.Module] = set()
+    for name in _CONTROLNET_SHARED_NAMES:
+        mod = getattr(diffusion_model, name, None)
+        if mod is not None and isinstance(mod, torch.nn.Module) and any(True for _ in mod.parameters()):
+            excluded.add(mod)
+    return excluded
+
+
 def patch_fsdp(self):
     print(f"[Rank {self.rank}] Applying FSDP to {type(self.model.diffusion_model).__name__}")
 
@@ -189,12 +244,23 @@ def patch_fsdp(self):
         if replaced > 0:
             print(f"[Rank {self.rank}] Promoted {replaced} non-floating quant params to meta placeholders before FSDP wrapping")
 
-    fully_shard_bottom_up(diffusion_model, fsdp_kwargs=fsdp_kwargs, native_ignore_scale=not use_quant_loader)
+    excluded_modules = _collect_controlnet_shared_modules(diffusion_model)
+    if excluded_modules:
+        print(f"[Rank {self.rank}] Excluding {len(excluded_modules)} ControlNet-shared modules from FSDP: "
+              f"{[n for n, m in diffusion_model.named_modules() if m in excluded_modules]}")
+
+    fully_shard_bottom_up(
+        diffusion_model,
+        fsdp_kwargs=fsdp_kwargs,
+        native_ignore_scale=not use_quant_loader,
+        ignored_modules=excluded_modules,
+    )
+
+    target_device = (
+        self.load_device if isinstance(self.load_device, torch.device) else torch.device("cuda", torch.cuda.current_device())
+    )
 
     if use_quant_loader:
-        target_device = (
-            self.load_device if isinstance(self.load_device, torch.device) else torch.device("cuda", torch.cuda.current_device())
-        )
         load_from_full_model_state_dict(
             model=self.model,
             full_sd=self.fsdp_state_dict,
@@ -211,7 +277,23 @@ def patch_fsdp(self):
             broadcast_from_rank0=True,
         )
         set_model_state_dict(self.model, self.fsdp_state_dict, options=options)
-        self.fsdp_state_dict = None
+
+    # Materialize excluded params AFTER state dict loading so that
+    # set_model_state_dict only sees meta-device params (single device).
+    if excluded_modules:
+        count = materialize_excluded_params(
+            model=self.model,
+            excluded_modules=excluded_modules,
+            full_sd=self.fsdp_state_dict,
+            device=target_device,
+            cpu_offload=self.is_cpu_offload,
+        )
+        if count > 0:
+            print(f"[Rank {self.rank}] Materialized {count} excluded ControlNet-shared params on {target_device}")
+
+    self.fsdp_state_dict = None
+
+    _pre_init_fsdp(diffusion_model)
 
     print("FSDP registered successfully.")
     return self.model
@@ -246,6 +328,17 @@ class FSDPModelPatcher(comfy.model_patcher.ModelPatcher):
 
     def is_dynamic(self):
         return True
+
+    def model_size(self):
+        if self.size > 0:
+            return self.size
+        total = comfy.model_management.module_size(self.model)
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        if world_size > 1:
+            self.size = total // world_size
+        else:
+            self.size = total
+        return self.size
 
     def config_fsdp(self, rank, device_mesh):
         self.rank = rank
@@ -445,6 +538,7 @@ class FSDPModelPatcher(comfy.model_patcher.ModelPatcher):
             self.model.model_loaded_weight_memory = mem_counter
             self.model.model_offload_buffer_memory = 0
             self.model.current_weight_patches_uuid = self.patches_uuid
+            self.model.current_patcher = self
 
             for callback in self.get_all_callbacks(CallbacksMP.ON_LOAD):
                 callback(self, device_to, lowvram_model_memory, force_patch_weights, full_load)
@@ -522,43 +616,6 @@ class FSDPModelPatcher(comfy.model_patcher.ModelPatcher):
             # Break reference cycle so the inner model can be collected
             if hasattr(model, "current_patcher"):
                 model.current_patcher = None
-            try:
-                has_qt_hint = self._has_quantized_dtensor_shards
-                for m in model.modules():
-                    for p in m.parameters(recurse=False):
-                        try:
-                            tensor = p.data if isinstance(p, torch.Tensor) else None
-                            if tensor is None:
-                                continue
-
-                            if isinstance(tensor, DTensor):
-                                if has_qt_hint is True:
-                                    continue
-
-                                try:
-                                    local = getattr(tensor, "_local_tensor", None)
-                                    if local is None:
-                                        local = tensor.to_local()
-                                except Exception:
-                                    continue
-
-                                if has_qt_hint is None:
-                                    has_qt_hint = _is_quantized_tensor_like(local)
-                                    self._has_quantized_dtensor_shards = has_qt_hint
-
-                                if has_qt_hint is True:
-                                    continue
-                                _safe_free_storage(local.data)
-                                continue
-
-                            if _is_quantized_tensor_like(tensor):
-                                continue
-
-                            _safe_free_storage(tensor.data)
-                        except Exception:
-                            continue
-            except Exception:
-                pass
 
         self.model = None
         try:

--- a/src/raylight/diffusion_models/chroma/xdit_context_parallel.py
+++ b/src/raylight/diffusion_models/chroma/xdit_context_parallel.py
@@ -163,6 +163,9 @@ def usp_dit_forward(
                 if i < len(control_i):
                     add = control_i[i]
                     if add is not None:
+                        # Pad + chunk control signal to match USP sequence split
+                        add, _ = pad_to_world_size(add, dim=1)
+                        add = torch.chunk(add, get_sequence_parallel_world_size(), dim=1)[get_sequence_parallel_rank()]
                         img += add
 
     # ======================== ADD SEQUENCE PARALLEL ========================= #
@@ -203,7 +206,15 @@ def usp_dit_forward(
                 if i < len(control_o):
                     add = control_o[i]
                     if add is not None:
-                        img[:, txt.shape[1]:, ...] += add
+                        # Embed control signal in full concatenated [txt, img] space, then pad+chunk
+                        sp_ws = get_sequence_parallel_world_size()
+                        sp_r = get_sequence_parallel_rank()
+                        txt_len = txt.shape[1]
+                        full_add = torch.zeros(img.shape[0], img_orig_size, add.shape[-1],
+                                               device=add.device, dtype=add.dtype)
+                        full_add[:, txt_len:txt_len + add.shape[1]] = add
+                        full_add, _ = pad_to_world_size(full_add, dim=1)
+                        img += torch.chunk(full_add, sp_ws, dim=1)[sp_r]
 
     # ======================== ADD SEQUENCE PARALLEL ========================= #
     img = get_sp_group().all_gather(img.contiguous(), dim=1)

--- a/src/raylight/diffusion_models/flux/xdit_context_parallel.py
+++ b/src/raylight/diffusion_models/flux/xdit_context_parallel.py
@@ -204,6 +204,9 @@ def usp_dit_forward(
             if i < len(control_i):
                 add = control_i[i]
                 if add is not None:
+                    # Pad + chunk control signal to match USP sequence split
+                    add, _ = pad_to_world_size(add, dim=1)
+                    add = torch.chunk(add, get_sequence_parallel_world_size(), dim=1)[get_sequence_parallel_rank()]
                     img[:, :add.shape[1]] += add
     # ======================== ADD SEQUENCE PARALLEL ========================= #
     img = get_sp_group().all_gather(img.contiguous(), dim=1)
@@ -261,7 +264,15 @@ def usp_dit_forward(
             if i < len(control_o):
                 add = control_o[i]
                 if add is not None:
-                    img[:, txt.shape[1]:txt.shape[1] + add.shape[1], ...] += add
+                    # Embed control signal in full concatenated [txt, img] space, then pad+chunk
+                    sp_ws = get_sequence_parallel_world_size()
+                    sp_r = get_sequence_parallel_rank()
+                    txt_len = txt.shape[1]
+                    full_add = torch.zeros(img.shape[0], img_orig_size, add.shape[-1],
+                                           device=add.device, dtype=add.dtype)
+                    full_add[:, txt_len:txt_len + add.shape[1]] = add
+                    full_add, _ = pad_to_world_size(full_add, dim=1)
+                    img += torch.chunk(full_add, sp_ws, dim=1)[sp_r]
 
     # ======================== ADD SEQUENCE PARALLEL ========================= #
     img = get_sp_group().all_gather(img.contiguous(), dim=1)

--- a/src/raylight/diffusion_models/hunyuan_video/xdit_context_parallel.py
+++ b/src/raylight/diffusion_models/hunyuan_video/xdit_context_parallel.py
@@ -227,6 +227,9 @@ def usp_dit_forward(
             if i < len(control_i):
                 add = control_i[i]
                 if add is not None:
+                    # Pad + chunk control signal to match USP sequence split
+                    add, _ = pad_to_world_size(add, dim=1)
+                    add = torch.chunk(add, get_sequence_parallel_world_size(), dim=1)[get_sequence_parallel_rank()]
                     img += add
 
     # ======================== ADD SEQUENCE PARALLEL ========================= #
@@ -276,7 +279,15 @@ def usp_dit_forward(
             if i < len(control_o):
                 add = control_o[i]
                 if add is not None:
-                    img[:, txt.shape[1]: img_len + txt.shape[1]] += add
+                    # Embed control signal in full concatenated [txt, img] space, then pad+chunk
+                    sp_ws = get_sequence_parallel_world_size()
+                    sp_r = get_sequence_parallel_rank()
+                    txt_len = txt.shape[1]
+                    full_add = torch.zeros(img.shape[0], img_orig_size, add.shape[-1],
+                                           device=add.device, dtype=add.dtype)
+                    full_add[:, txt_len:txt_len + add.shape[1]] = add
+                    full_add, _ = pad_to_world_size(full_add, dim=1)
+                    img += torch.chunk(full_add, sp_ws, dim=1)[sp_r]
 
     # ======================== ADD SEQUENCE PARALLEL ========================= #
     img = get_sp_group().all_gather(img.contiguous(), dim=1)

--- a/src/raylight/diffusion_models/qwen_image/xdit_context_parallel.py
+++ b/src/raylight/diffusion_models/qwen_image/xdit_context_parallel.py
@@ -178,6 +178,9 @@ def usp_dit_forward(
             if i < len(control_i):
                 add = control_i[i]
                 if add is not None:
+                    # Pad + chunk control signal to match USP sequence split
+                    add, _ = pad_to_world_size(add, dim=1)
+                    add = torch.chunk(add, sp_world_size, dim=1)[sp_rank]
                     hidden_states[:, :add.shape[1]] += add
 
     if timestep_zero_index is not None:

--- a/src/raylight/distributed_worker/ray_worker.py
+++ b/src/raylight/distributed_worker/ray_worker.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import gc
+import types
 import functools
 from datetime import timedelta
 
@@ -36,6 +37,223 @@ from raylight.comfy_dist.quant_ops import patch_temp_fix_ck_ops
 from ray.exceptions import RayActorError
 
 
+class _RayControlNetRef:
+    """Lightweight placeholder for a ControlNet in conditioning.
+
+    Created by RayControlNetApply in the main process.  Carries only the
+    hint image and apply settings — no model weights.  Workers replace
+    this with a real ControlNet loaded from their local cache.
+    """
+
+    def __init__(self, strength, timestep_percent_range, cond_hint_original,
+                 extra_concat_orig=None, previous_controlnet=None, needs_vae=False):
+        self.strength = strength
+        self.timestep_percent_range = timestep_percent_range
+        self.cond_hint_original = cond_hint_original
+        self.extra_concat_orig = list(extra_concat_orig or [])
+        self.previous_controlnet = previous_controlnet
+        self.needs_vae = needs_vae
+
+        # ControlBase interface stubs needed by ComfyUI internals
+        self.cond_hint = None
+        self.global_average_pooling = False
+        self.compression_ratio = 1
+        self.upscale_algorithm = "nearest-exact"
+        self.extra_args = {}
+        self.extra_conds = []
+        self.strength_type = None
+        self.concat_mask = False
+        self.extra_hooks = None
+        self.preprocess_image = lambda a: a
+        self.model_sampling_current = None
+        self.latent_format = None
+        self.vae = None
+
+    def set_cond_hint(self, *args, **kwargs):
+        pass
+
+    def set_previous_controlnet(self, prev):
+        self.previous_controlnet = prev
+
+    def copy(self):
+        c = _RayControlNetRef(
+            self.strength,
+            self.timestep_percent_range,
+            self.cond_hint_original,
+            self.extra_concat_orig,
+            self.previous_controlnet,
+            self.needs_vae,
+        )
+        return c
+
+    def pre_run(self, model, percent_to_timestep_function):
+        pass
+
+    def get_models(self):
+        return []
+
+    def get_extra_hooks(self):
+        hooks = []
+        if self.previous_controlnet is not None:
+            hooks += self.previous_controlnet.get_extra_hooks()
+        return hooks
+
+    def cleanup(self):
+        pass
+
+    def inference_memory_requirements(self, dtype):
+        return 0
+
+
+def _restore_controlnet_refs(cond_list, cached_controlnet, worker_vae=None):
+    """Replace _RayControlNetRef placeholders with real ControlNet objects."""
+    if cond_list is None or cached_controlnet is None:
+        return
+
+    _, cnet_template = cached_controlnet
+
+    for item in cond_list:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            d = item[1]
+        elif isinstance(item, dict):
+            d = item
+        else:
+            continue
+        if not isinstance(d, dict):
+            continue
+
+        control = d.get("control")
+        if not isinstance(control, _RayControlNetRef):
+            continue
+
+        cnet = cnet_template.copy()
+        cnet.cond_hint_original = control.cond_hint_original
+        cnet.strength = control.strength
+        cnet.timestep_percent_range = control.timestep_percent_range
+        if control.extra_concat_orig:
+            cnet.extra_concat_orig = list(control.extra_concat_orig)
+        if control.needs_vae and worker_vae is not None:
+            cnet.vae = worker_vae
+        if control.previous_controlnet is not None:
+            prev = control.previous_controlnet
+            if isinstance(prev, _RayControlNetRef):
+                prev_cnet = cnet_template.copy()
+                prev_cnet.cond_hint_original = prev.cond_hint_original
+                prev_cnet.strength = prev.strength
+                prev_cnet.timestep_percent_range = prev.timestep_percent_range
+                if prev.extra_concat_orig:
+                    prev_cnet.extra_concat_orig = list(prev.extra_concat_orig)
+                if prev.needs_vae and worker_vae is not None:
+                    prev_cnet.vae = worker_vae
+                cnet.set_previous_controlnet(prev_cnet)
+            else:
+                cnet.set_previous_controlnet(prev)
+
+        d["control"] = cnet
+
+
+def _remap_conditioning_devices(positive, negative):
+    """Remap CUDA device references in conditioning to cuda:0.
+
+    Conditioning is created in the main ComfyUI process where CUDA device
+    indices map to physical GPUs.  Inside a ray worker, CUDA_VISIBLE_DEVICES
+    is set to a single physical GPU, so only cuda:0 is valid.  Any model
+    device (VAE, ControlNet, etc.) that references cuda:N (N>0) will fail.
+    """
+    target = torch.device("cuda:0")
+    for cond_list in (positive, negative):
+        if cond_list is None:
+            continue
+        for item in cond_list:
+            # Conditioning items are [tensor, dict] — the dict is at index 1.
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                cond = item[1]
+            elif isinstance(item, dict):
+                cond = item
+            else:
+                continue
+            if not isinstance(cond, dict):
+                continue
+            control = cond.get("control")
+            if control is not None:
+                _remap_control_devices(control, target)
+
+
+def _remap_control_devices(control, target):
+    vae = getattr(control, "vae", None)
+    if vae is not None:
+        _remap_cuda_device(vae, "device", target)
+        _remap_cuda_device(vae, "output_device", target)
+        patcher = getattr(vae, "patcher", None)
+        if patcher is not None:
+            _remap_patcher_device(patcher, target)
+    model_wrapped = getattr(control, "control_model_wrapped", None)
+    if model_wrapped is not None:
+        _remap_patcher_device(model_wrapped, target)
+    _remap_cuda_device(control, "load_device", target)
+    prev = getattr(control, "previous_controlnet", None)
+    if prev is not None:
+        _remap_control_devices(prev, target)
+
+
+def _move_control_to_device(control, device):
+    """Move ControlNet model weights to the worker's GPU.
+
+    Ray deserializes the ControlNet model on CPU.  Without this, only rank 0
+    loads the model via load_models_gpu(), leaving other ranks unable to run
+    the ControlNet forward.  This ensures every rank has the model on its GPU.
+    """
+    model_wrapped = getattr(control, "control_model_wrapped", None)
+    if model_wrapped is not None:
+        model = getattr(model_wrapped, "model", None)
+        if model is not None:
+            try:
+                model.to(device)
+            except Exception:
+                pass
+    # Also move the hint tensor if it's already materialized
+    cond_hint = getattr(control, "cond_hint", None)
+    if isinstance(cond_hint, torch.Tensor) and cond_hint.device.type == "cpu":
+        try:
+            control.cond_hint = cond_hint.to(device)
+        except Exception:
+            pass
+    prev = getattr(control, "previous_controlnet", None)
+    if prev is not None:
+        _move_control_to_device(prev, device)
+
+
+def _prepare_control_models(positive, negative):
+    """Remap devices AND move ControlNet model weights to the worker's GPU."""
+    target = torch.device("cuda:0")
+    for cond_list in (positive, negative):
+        if cond_list is None:
+            continue
+        for item in cond_list:
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                cond = item[1]
+            elif isinstance(item, dict):
+                cond = item
+            else:
+                continue
+            if not isinstance(cond, dict):
+                continue
+            control = cond.get("control")
+            if control is not None:
+                _move_control_to_device(control, target)
+
+
+def _remap_patcher_device(patcher, target):
+    _remap_cuda_device(patcher, "load_device", target)
+    _remap_cuda_device(patcher, "offload_device", target)
+
+
+def _remap_cuda_device(obj, attr, target):
+    val = getattr(obj, attr, None)
+    if isinstance(val, torch.device) and val.type == "cuda":
+        setattr(obj, attr, target)
+
+
 # Developer reminder, Checking model parameter outside ray actor is very expensive (e.g Comfy main thread)
 # the model need to be serialized, send to object store and can cause OOM !, so setter and getter is the pattern !
 
@@ -64,6 +282,7 @@ class RayWorker:
         self.vae_model = None
         self.model_type = None
         self.state_dict = None
+        self.cached_controlnet = None  # (path, controlnet_object) cache
         self.lora_list = None
         self.parallel_dict = parallel_dict
         self.overwrite_cast_dtype = None
@@ -138,6 +357,23 @@ class RayWorker:
             self.model.config_fsdp(self.local_rank, self.device_mesh)
         else:
             raise ValueError("Model being set is not meta, can cause OOM in large model")
+
+    def _free_cached_aux_models(self):
+        """Free cached ControlNet and VAE GPU memory."""
+        if self.cached_controlnet is not None:
+            _, old_cnet = self.cached_controlnet
+            old_model = getattr(old_cnet, "control_model", None)
+            if old_model is not None:
+                del old_model
+            self.cached_controlnet = None
+
+        if self.vae_model is not None:
+            del self.vae_model
+            self.vae_model = None
+            self._cached_vae_path = None
+
+        torch.cuda.empty_cache()
+        gc.collect()
 
     def _normalize_model_options(self, model_options):
         if not model_options:
@@ -345,6 +581,7 @@ class RayWorker:
                     self.model.free_fsdp_vram()
                 except Exception as e:
                     print(f"[Rank {self.local_rank}] free_fsdp_vram failed: {e}")
+                self._free_cached_aux_models()
 
 
             # Monkey patch
@@ -430,6 +667,7 @@ class RayWorker:
 
             self._reset_active_model()
             self._invalidate_non_fsdp_cache()
+            self._free_cached_aux_models()
             if self.parallel_dict.get("pipefusion_enabled"):
                 from raylight.comfy_dist.sd import pipefusion_load_diffusion_model
 
@@ -471,6 +709,7 @@ class RayWorker:
     def load_gguf_unet(self, unet_path, dequant_dtype, patch_dtype, use_mmap=None):
         self._reset_active_model()
         self._invalidate_non_fsdp_cache()
+        self._free_cached_aux_models()
         if use_mmap is None:
             use_mmap = self.parallel_dict.get("use_mmap", True)
         if self.parallel_dict["is_fsdp"] is True:
@@ -539,12 +778,23 @@ class RayWorker:
             del lora_model
 
     def kill(self):
+        self._free_cached_aux_models()
         self._invalidate_non_fsdp_cache()
         self.model = None
         dist.destroy_process_group()
         ray.actor.exit_actor()
 
     def ray_vae_loader(self, vae_path):
+        if self.vae_model is not None and getattr(self, "_cached_vae_path", None) == vae_path:
+            return
+
+        # Free old VAE before loading new one
+        if self.vae_model is not None:
+            del self.vae_model
+            self.vae_model = None
+            self._cached_vae_path = None
+            torch.cuda.empty_cache()
+
         import comfy.sd as comfy_sd
         import comfy.utils as comfy_utils
 
@@ -568,6 +818,7 @@ class RayWorker:
         if self.local_rank == 0:
             print(f"VAE loaded in {self.global_world_size} GPUs")
         self.vae_model = vae_model
+        self._cached_vae_path = vae_path
 
     @patch_ray_tqdm
     def ray_vae_decode(self, samples, tile_size, overlap=64, temporal_size=64, temporal_overlap=8):
@@ -615,6 +866,10 @@ class RayWorker:
         import comfy.sample as comfy_sample
         import comfy.utils as comfy_utils
 
+        # Restore ControlNet refs from local cache (loaded by load_controlnet)
+        _restore_controlnet_refs(positive, self.cached_controlnet, self.vae_model)
+        _restore_controlnet_refs(negative, self.cached_controlnet, self.vae_model)
+
         latent = latent_image
         latent_image = latent["samples"]
         latent = latent.copy()
@@ -629,6 +884,9 @@ class RayWorker:
         noise_mask = None
         if "noise_mask" in latent:
             noise_mask = latent["noise_mask"]
+
+        _remap_conditioning_devices(positive, negative)
+        _prepare_control_models(positive, negative)
 
         if self.parallel_dict["is_fsdp"] is True:
             self.model.patch_fsdp()
@@ -667,6 +925,62 @@ class RayWorker:
         gc.collect()
         return out
 
+    def load_controlnet(self, controlnet_path):
+        """Load a ControlNet model from disk into the worker.
+
+        Caches the result so subsequent calls with the same path are free.
+        Frees old ControlNet VRAM when the path changes.
+        Returns True on success.
+        """
+        if self.cached_controlnet is not None and self.cached_controlnet[0] == controlnet_path:
+            return True
+
+        # Free old ControlNet VRAM if model changed
+        if self.cached_controlnet is not None:
+            _, old_cnet = self.cached_controlnet
+            old_model = getattr(old_cnet, "control_model", None)
+            if old_model is not None:
+                del old_model
+            self.cached_controlnet = None
+            torch.cuda.empty_cache()
+            gc.collect()
+
+        import comfy.controlnet as comfy_cnet
+
+        cnet = comfy_cnet.load_controlnet(controlnet_path)
+        if cnet is None:
+            print(f"[Rank {self.local_rank}] Failed to load ControlNet: {controlnet_path}")
+            return False
+
+        self.cached_controlnet = (controlnet_path, cnet)
+        if self.local_rank == 0:
+            print(f"[Rank {self.local_rank}] ControlNet loaded and cached from {controlnet_path}")
+        return True
+
+    def free_cached_controlnet(self):
+        """Explicitly free the cached ControlNet (e.g. when switching workflows)."""
+        if self.cached_controlnet is not None:
+            _, old_cnet = self.cached_controlnet
+            old_model = getattr(old_cnet, "control_model", None)
+            if old_model is not None:
+                del old_model
+            self.cached_controlnet = None
+            torch.cuda.empty_cache()
+            gc.collect()
+            if self.local_rank == 0:
+                print(f"[Rank {self.local_rank}] ControlNet cache freed")
+
+    def free_cached_vae(self):
+        """Explicitly free the cached VAE (e.g. when switching workflows)."""
+        if self.vae_model is not None:
+            del self.vae_model
+            self.vae_model = None
+            self._cached_vae_path = None
+            torch.cuda.empty_cache()
+            gc.collect()
+            if self.local_rank == 0:
+                print(f"[Rank {self.local_rank}] VAE cache freed")
+
     @patch_temp_fix_ck_ops
     @patch_ray_tqdm
     @patch_enable_comfy_kitchen_fsdp
@@ -690,6 +1004,10 @@ class RayWorker:
         import comfy.sample as comfy_sample
         import comfy.utils as comfy_utils
 
+        # Restore ControlNet refs from local cache (loaded by load_controlnet)
+        _restore_controlnet_refs(positive, self.cached_controlnet, self.vae_model)
+        _restore_controlnet_refs(negative, self.cached_controlnet, self.vae_model)
+
         latent_image = latent["samples"]
         latent_image = comfy_sample.fix_empty_latent_channels(self.model, latent_image)
 
@@ -710,6 +1028,9 @@ class RayWorker:
         noise_mask = None
         if "noise_mask" in latent:
             noise_mask = latent["noise_mask"]
+
+        _remap_conditioning_devices(positive, negative)
+        _prepare_control_models(positive, negative)
 
         disable_pbar = comfy_utils.PROGRESS_BAR_ENABLED
         if self.local_rank == 0:

--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -1,6 +1,7 @@
 import raylight
 import os
 import gc
+import shutil
 from typing import Any
 from pathlib import Path
 from copy import deepcopy
@@ -19,6 +20,18 @@ from .distributed_worker.ray_worker import (
     ensure_fresh_actors,
     ray_nccl_tester,
 )
+
+
+def _cleanup_ray_temp():
+    """Remove stale Ray plasma/session directories from previous runs."""
+    ray_tmpdir = os.environ.get("RAY_TMPDIR", "/tmp")
+    ray_dir = os.path.join(ray_tmpdir, "ray")
+    if not os.path.isdir(ray_dir):
+        return
+    try:
+        shutil.rmtree(ray_dir, ignore_errors=True)
+    except Exception:
+        pass
 
 
 # Workaround https://github.com/comfyanonymous/ComfyUI/pull/11134
@@ -391,6 +404,8 @@ class RayInitializer:
         try:
             # Shut down so if comfy user try another workflow it will not cause error
             ray.shutdown()
+            _cleanup_ray_temp()
+            RayControlNetLoader._current_controlnet_path = None
             original_cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
             restricted_cuda_visible_devices = runtime_env_base.get("env_vars", {}).get("CUDA_VISIBLE_DEVICES")
             if restricted_cuda_visible_devices is not None:
@@ -413,6 +428,7 @@ class RayInitializer:
                         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         except Exception as e:
             ray.shutdown()
+            _cleanup_ray_temp()
             if restricted_cuda_visible_devices is not None:
                 os.environ["CUDA_VISIBLE_DEVICES"] = restricted_cuda_visible_devices
             try:
@@ -1012,8 +1028,169 @@ class RayKill:
 
         if kill_mode == "Kill Entire Cluster":
             ray.shutdown()
+            _cleanup_ray_temp()
+            RayControlNetLoader._current_controlnet_path = None
 
         return ()
+
+
+class RayControlNetLoader:
+    """Load a ControlNet model into all Ray workers.
+
+    Works like the standard ControlNetLoader but loads the model on each
+    worker's GPU from disk, avoiding Ray serialization of multi-GB weights.
+    Returns a lightweight reference that RayControlNetApply uses.
+
+    Only one ControlNet model per workflow is supported. To apply the same
+    model with different images/strengths, use multiple RayControlNetApply
+    nodes connected to a single RayControlNetLoader.
+    """
+
+    _current_controlnet_path = None
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "ray_actors": ("RAY_ACTORS",),
+                "control_net_name": (folder_paths.get_filename_list("controlnet"),),
+            }
+        }
+
+    RETURN_TYPES = ("RAY_CONTROL_NET",)
+    FUNCTION = "load_controlnet"
+    CATEGORY = "Raylight"
+
+    def load_controlnet(self, ray_actors, control_net_name):
+        controlnet_path = folder_paths.get_full_path_or_raise("controlnet", control_net_name)
+
+        if (RayControlNetLoader._current_controlnet_path is not None
+                and RayControlNetLoader._current_controlnet_path != controlnet_path):
+            raise RuntimeError(
+                f"Only one ControlNet model per workflow is supported. "
+                f"Already loaded '{RayControlNetLoader._current_controlnet_path}', "
+                f"attempted '{controlnet_path}'. Use multiple RayControlNetApply nodes "
+                f"to apply the same model with different images."
+            )
+        RayControlNetLoader._current_controlnet_path = controlnet_path
+
+        # Validate the ControlNet loads in the main process first
+        controlnet = comfy.controlnet.load_controlnet(controlnet_path)
+        if controlnet is None:
+            raise RuntimeError(f"Invalid ControlNet file: {control_net_name}")
+        del controlnet
+        gc.collect()
+
+        # Send the path to all workers — each loads from disk independently
+        gpu_actors = ray_actors["workers"]
+        futures = [actor.load_controlnet.remote(controlnet_path) for actor in gpu_actors]
+        results = ray.get(futures)
+        if not all(results):
+            raise RuntimeError(f"Failed to load ControlNet on one or more workers: {control_net_name}")
+
+        return (controlnet_path,)
+
+
+class RayControlNetApply:
+    """Apply a Ray-loaded ControlNet to conditioning.
+
+    Works like ApplyControlNet but uses a lightweight reference instead of
+    embedding the full model in the conditioning data.  The workers restore
+    the real ControlNet from their local cache during sampling.
+    """
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "ray_control_net": ("RAY_CONTROL_NET",),
+                "image": ("IMAGE",),
+                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
+                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+            },
+            "optional": {
+                "ray_vae": ("RAY_VAE",),
+            },
+        }
+
+    RETURN_TYPES = ("CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("positive", "negative")
+    FUNCTION = "apply_controlnet"
+    CATEGORY = "Raylight"
+
+    def apply_controlnet(self, positive, negative, ray_control_net, image, strength,
+                         start_percent, end_percent, ray_vae=None, extra_concat=None):
+        from .distributed_worker.ray_worker import _RayControlNetRef
+
+        if strength == 0:
+            return (positive, negative)
+
+        if extra_concat is None:
+            extra_concat = []
+
+        control_hint = image.movedim(-1, 1)
+        cnets = {}
+
+        out = []
+        for conditioning in [positive, negative]:
+            c = []
+            for t in conditioning:
+                d = t[1].copy()
+
+                prev_cnet = d.get("control", None)
+                if prev_cnet in cnets:
+                    c_net = cnets[prev_cnet]
+                else:
+                    c_net = _RayControlNetRef(
+                        strength=strength,
+                        timestep_percent_range=(start_percent, end_percent),
+                        cond_hint_original=control_hint,
+                        extra_concat_orig=extra_concat,
+                        needs_vae=(ray_vae is not None),
+                    )
+                    if prev_cnet is not None:
+                        c_net.set_previous_controlnet(prev_cnet)
+                    cnets[prev_cnet] = c_net
+
+                d["control"] = c_net
+                d["control_apply_to_uncond"] = False
+                n = [t[0], d]
+                c.append(n)
+            out.append(c)
+        return (out[0], out[1])
+
+
+class RayVAELoader:
+    """Load a VAE model into all Ray workers.
+
+    Loads the VAE on each worker's GPU from disk.  Used by RayControlNetApply
+    when the ControlNet requires a VAE (e.g. for encoding the control image).
+    """
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "ray_actors": ("RAY_ACTORS",),
+                "vae_name": (folder_paths.get_filename_list("vae"),),
+            }
+        }
+
+    RETURN_TYPES = ("RAY_VAE",)
+    FUNCTION = "load_vae"
+    CATEGORY = "Raylight"
+
+    def load_vae(self, ray_actors, vae_name):
+        vae_path = folder_paths.get_full_path_or_raise("vae", vae_name)
+
+        gpu_actors = ray_actors["workers"]
+        for actor in gpu_actors:
+            ray.get(actor.ray_vae_loader.remote(vae_path))
+
+        return (vae_path,)
 
 
 class Noise_RandomNoise:
@@ -1160,6 +1337,9 @@ NODE_CLASS_MAPPINGS = {
     "RayKill": RayKill,
     "RayUNETLoader": RayUNETLoader,
     "RayLoraLoader": RayLoraLoader,
+    "RayControlNetLoader": RayControlNetLoader,
+    "RayControlNetApply": RayControlNetApply,
+    "RayVAELoader": RayVAELoader,
     "RayInitializer": RayInitializer,
     "RayInitializerAdvanced": RayInitializerAdvanced,
     "DPNoiseList": DPNoiseList,
@@ -1173,6 +1353,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "RayKill": "Kill Ray",
     "RayUNETLoader": "Load Diffusion Model (Ray)",
     "RayLoraLoader": "Load Lora Model (Ray)",
+    "RayControlNetLoader": "Load ControlNet (Ray)",
+    "RayControlNetApply": "Apply ControlNet (Ray)",
+    "RayVAELoader": "Load VAE (Ray)",
     "RayInitializer": "Ray Init Actor",
     "RayInitializerAdvanced": "Ray Init Actor (Advanced)",
     "DPNoiseList": "Data Parallel Noise List",


### PR DESCRIPTION
## TL;DR

**What:** Add ControlNet support for distributed inference across USP (sequence parallel) and FSDP, with Ray-native loader/apply nodes that avoid serializing multi-GB weights through Ray.
**Why:** ControlNet was completely broken with USP (full-sequence signals added to split hidden states) and with FSDP (shared module calls triggered NCCL timeouts). No Ray-native way to load ControlNet without shipping weights through the object store.
**How:** USP forward functions now pad+chunk ControlNet signals to match the sequence-parallel split. FSDP excludes ControlNet-shared base modules from sharding and materializes them independently. New `_RayControlNetRef` placeholder pattern lets workers load ControlNet from disk. Guard prevents loading multiple different ControlNet models per workflow.

## What

9 files changed, 666 insertions, 51 deletions:

- **`src/raylight/diffusion_models/flux/xdit_context_parallel.py`** — Double-block: pad+chunk ControlNet `add` to match USP split before adding to `img`. Single-block: embed `add` in full concatenated `[txt, img]` space, pad+chunk, then add to split `img`.
- **`src/raylight/diffusion_models/chroma/xdit_context_parallel.py`** — Same double-block and single-block pad+chunk pattern as Flux.
- **`src/raylight/diffusion_models/hunyuan_video/xdit_context_parallel.py`** — Same double-block and single-block pad+chunk pattern as Flux.
- **`src/raylight/diffusion_models/qwen_image/xdit_context_parallel.py`** — Double-block pad+chunk (Qwen Image has no single-block output control).
- **`src/raylight/comfy_dist/model_patcher.py`** — Added `_collect_controlnet_shared_modules()` to identify base model modules called directly by ControlNet (img_in, time_in, vector_in, guidance_in, txt_in, pe_embedder, etc.). These are excluded from FSDP wrapping via `ignored_modules` in `fully_shard_bottom_up`. Added `_pre_init_fsdp()` to eagerly init FSDP root state, preventing partial initialization when ControlNet calls nested modules. Added `model_size()` that divides by `world_size` since FSDP `module_size()` returns unsharded totals. Removed redundant VRAM teardown in `__del__` (already handled by `free_fsdp_vram()`). Added `model.current_patcher = self` assignment for ControlNet access.
- **`src/raylight/comfy_dist/fsdp_utils.py`** — Added `ignored_modules` parameter to `fully_shard_bottom_up`: filters excluded modules from shard order and merges their parameters into `ignored_params` for each FSDP unit. Added `materialize_excluded_params()` to load excluded-module weights from state dict after FSDP wrapping (they stay on meta device since they weren't sharded).
- **`src/raylight/distributed_worker/ray_worker.py`** — Added `_RayControlNetRef` lightweight placeholder (carries hint image + settings, no weights). Added `_restore_controlnet_refs()` to replace placeholders with real ControlNets from worker cache, including recursive restoration of chained `previous_controlnet` refs. Added `_remap_conditioning_devices()` and `_prepare_control_models()` to remap CUDA device indices from main process to worker's `cuda:0`. Added `load_controlnet()` / `free_cached_controlnet()` / `free_cached_vae()` for worker-side caching. Added `_free_cached_aux_models()` called on model switch, workflow change, and actor kill. Fixed infinite recursion bug (was calling itself instead of `gc.collect()`).
- **`src/raylight/nodes.py`** — Added `RayControlNetLoader` (loads ControlNet on all workers from disk, validates in main process, frees validation model immediately). Added `RayControlNetApply` (creates `_RayControlNetRef` placeholders in conditioning, supports chaining via `previous_controlnet`). Added `RayVAELoader` (loads VAE on all workers, needed by ControlNets that encode hint images). Added single-model guard: `RayControlNetLoader._current_controlnet_path` errors on second different model, reset on cluster restart. Added `_cleanup_ray_temp()` for stale Ray session directories on init and kill.
- **`README.md`** — Updated ControlNet support matrix: Flux ✅, Qwen ✅, Chroma ✅†, Hunyuan ✅† († = code-ready, no weights available). Added legend entry and notes about single-model limitation.

## Why

ControlNet had two independent failure modes with distributed inference:

1. **USP (sequence parallel):** The base model's hidden states are split across GPUs by sequence dimension, but ControlNet output signals (`add` tensors) were full-sequence. Adding a full-sequence tensor to a split tensor produced silent corruption or shape mismatches. This affected all four model architectures.

2. **FSDP:** ControlNet implementations call base model modules directly (e.g., `base_model.img_in()`, `base_model.time_in()`). When these modules are FSDP-wrapped, each call triggers an all_gather that only some ranks participate in, causing NCCL collective timeouts.

Additionally, there was no Ray-native way to load ControlNet — standard ComfyUI loading would serialize multi-GB weights through Ray's object store, causing OOM or excessive tmp directory growth.

## How

**USP fix — double blocks:** `img` is already USP-split but ControlNet `add` is full-sequence. Fix: `pad_to_world_size(add, dim=1)` then `torch.chunk(add, sp_world_size, dim=1)[sp_rank]` to match the split.

**USP fix — single blocks:** After the double-block phase, `img` and `txt` are all_gathered, concatenated into `[txt, img]`, then re-split. The image tokens no longer start at a fixed offset — the offset is rank-dependent. Fix: embed `add` in a zero tensor of full concatenated size (`img_orig_size`), place `add` at offset `txt_len`, then pad+chunk the full tensor. Each rank's chunk gets the correct slice of the control signal.

**FSDP fix:** `_collect_controlnet_shared_modules()` uses getattr to collect modules by name (skipping names that don't exist on a given architecture). `fully_shard_bottom_up` receives these as `ignored_modules`, filters them from the shard order, and adds their parameters to each FSDP unit's `ignored_params`. After state dict loading, `materialize_excluded_params()` loads these parameters from the full state dict onto the target device. `_pre_init_fsdp()` eagerly inits the FSDP root so ControlNet calls to nested modules don't trigger partial initialization.

**Ray ControlNet loading:** Main process validates the model loads (then immediately frees it). Workers load from disk independently and cache by path. `_RayControlNetRef` placeholder carries only the hint image and apply settings — no weights. During sampling, `_restore_controlnet_refs()` replaces placeholders with real cached ControlNets. `_remap_conditioning_devices()` fixes CUDA device indices (main process creates conditioning with physical GPU indices, but workers see only `cuda:0`).

**Single-model guard:** `RayControlNetLoader._current_controlnet_path` tracks the loaded model path. A second loader with a different path raises `RuntimeError`. Reset on `RayInitializer` and `RayKill`. Multiple `RayControlNetApply` nodes with the same loader are supported for applying the same model with different images/strengths.

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `raylight` — USP sequence parallel, FSDP sharding, Ray worker ControlNet lifecycle

## Breaking changes

- [x] No breaking changes — ControlNet was not previously supported. All new code is additive. Existing workflows without ControlNet are unaffected.

## Test plan

- [x] Manually tested — Qwen Image ControlNet (qwen-image-2512-fun-controlnet-union-2602) with FSDP (ulysses=0) and FSDP+USP (ulysses=3) on Kubuntu 24.04
- [ ] Flux ControlNet — not yet tested with real ControlNet weights on distributed setup
- [ ] Chroma / Hunyuan ControlNet — no ControlNet weights available in ComfyUI to test
- [ ] Ring attention (ring_degree > 1) with ControlNet — analyzed as correct but untested. For me with `ulysses=1`, `ring=3` and `FSDP=true` it OOMs, probably need to test with smaller model that would fit into single GPU with ControlNet model.
- [ ] CFG parallel (cfg_degree > 1) with ControlNet — analyzed as correct but untested
- [ ] No automated tests — runtime requires multi-GPU Ray cluster
- [x] Chained ControlNet apply tested

---
Implemented with GLM 5.1 + Claude Code.

Few numbers:
```
Setup											| 1st,s	| 2nd,s	|
-- FSDP + USP -> 1 image						|		|		|
4 gpu, 1 replica, 4 ulysses, cnet, 8 steps		| 221	| 85	| 4 x 15.7 GB (controlnet weights ~3GB are cloned to each GPU)
4 gpu, 1 replica, 4 ulysses, no cnet, 8 steps	| --	| 83	| 4 x 12.7 GB
3 gpu, 1 replica, 3 ulysses, cnet, 8 steps		| 209	| 64	| 3 x 18.9 GB
-- FSDP + DPKSampler -> 3 images				|		|		|
3 gpu, 1 replica, 0 ulysses, cnet, 8 steps		| 172	| 70	| 3 x 19.3 GB
-- FSDP + 2 model replicas + DPKSampler -> 6 images ( PR #80 )
6 gpu, 2 replica, 0 ulysses, cnet, 8 steps		| 314	| 113	|
```
* CLIP/VAE loaded to `cuda:0`, comfyUI started with `--gpu-only`

Workflow example:
<img width="2302" height="965" alt="image" src="https://github.com/user-attachments/assets/ee25a708-f9f9-480c-b177-f789cd876da2" />


