### PR TITLE
Fix comfy root dir resolve (` --base-directory`)

### DIFF
--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -73,7 +73,7 @@ def _resolve_module_dir(module):
 
 
 def _resolve_repo_root():
-    current = Path(__file__).resolve()
+    current = Path(folder_paths.__file__).resolve()
     for parent in current.parents:
         if (parent / "main.py").exists() and (parent / "execution.py").exists():
             return parent


### PR DESCRIPTION
Fix incompatibility with comfyui flag ` --base-directory`

Before fix:
```
Traceback (most recent call last):
  File "/comfyui/nodes.py", line 2227, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/data/custom_nodes/raylight/__init__.py", line 19, in <module>
    from raylight.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
  File "/data/custom_nodes/raylight/src/raylight/nodes.py", line 157, in <module>
    _COMFY_ROOT_PATH = _resolve_repo_root()
                       ^^^^^^^^^^^^^^^^^^^^
  File "/data/custom_nodes/raylight/src/raylight/nodes.py", line 80, in _resolve_repo_root
    raise RuntimeError("Unable to locate ComfyUI repository root")
RuntimeError: Unable to locate ComfyUI repository root
```