### PR TITLE
Strip cudaMallocAsync backend from Ray worker allocator config

### DIFF
--- a/src/raylight/nodes.py
+++ b/src/raylight/nodes.py
@@ -112,6 +112,40 @@ def _ensure_runtime_workdir(module_dir: Path) -> Path:
     return runtime_dir
 
 
+def _sanitized_worker_alloc_conf():
+    """Strip `backend:cudaMallocAsync` from PYTORCH_CUDA_ALLOC_CONF for Ray workers.
+
+    ComfyUI's cuda_malloc.py appends `backend:cudaMallocAsync` to
+    PYTORCH_CUDA_ALLOC_CONF in os.environ before torch is imported, and local
+    Ray workers inherit it. Under NCCL collectives (Ulysses/Ring all-to-all)
+    the cudaMallocAsync pool interacts badly with comm buffers: workers climb
+    to the VRAM ceiling and OOM within the first sampling steps, while the
+    native caching allocator completes the same workload with headroom
+    (observed with MiniMax H3 int8_convrot on 2x V100-32GB, torch 2.7.1+cu118;
+    single-GPU runs with cudaMallocAsync are unaffected).
+
+    Returns the cleaned value to inject into the worker env, or None to leave
+    the inherited env untouched. Set RAYLIGHT_KEEP_CUDA_MALLOC_ASYNC=1 to opt
+    out of the sanitization.
+    """
+    if os.environ.get("RAYLIGHT_KEEP_CUDA_MALLOC_ASYNC"):
+        return None
+    conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
+    if not conf:
+        return None
+    parts = [p for p in (part.strip() for part in conf.split(",")) if p]
+    kept = [p for p in parts if not p.startswith("backend:")]
+    if len(kept) == len(parts):
+        return None
+    print(
+        "[Raylight] Stripping allocator backend override from worker "
+        f"PYTORCH_CUDA_ALLOC_CONF ('{conf}' -> '{','.join(kept)}'); "
+        "cudaMallocAsync is known to OOM under NCCL collectives. "
+        "Set RAYLIGHT_KEEP_CUDA_MALLOC_ASYNC=1 to keep it."
+    )
+    return ",".join(kept)
+
+
 def _build_local_runtime_env(module_dir: Path, repo_root: Path, runtime_workdir: Path):
     python_path_entries = [str(repo_root)]
     existing = os.environ.get("PYTHONPATH")
@@ -123,6 +157,9 @@ def _build_local_runtime_env(module_dir: Path, repo_root: Path, runtime_workdir:
         "PYTHONPATH": python_path,
         "COMFYUI_BASE_DIRECTORY": str(repo_root),
     }
+    alloc_conf = _sanitized_worker_alloc_conf()
+    if alloc_conf is not None:
+        env_vars["PYTORCH_CUDA_ALLOC_CONF"] = alloc_conf
 
     return {
         "py_modules": [str(module_dir)],


### PR DESCRIPTION
## Problem

ComfyUI's `cuda_malloc.py` appends `backend:cudaMallocAsync` to `PYTORCH_CUDA_ALLOC_CONF` in `os.environ` before torch is imported (default behavior unless `--disable-cuda-malloc`). Local Ray workers inherit this env, so every Raylight worker silently runs on the cudaMallocAsync allocator.

Under NCCL collectives (USP all-to-all) that allocator interacts badly with comm buffers: workers climb to the VRAM ceiling and OOM within the first sampling steps. Single-GPU runs under cudaMallocAsync are unaffected — which makes this failure look like a model/VRAM problem rather than an allocator problem, and it is painful to diagnose (`torch.cuda.memory._record_memory_history` is also unsupported on cudaMallocAsync, so the standard debugging tool errors out).

## Repro / evidence

- MiniMax H3 fl2va `pruned_int8_convrot` (21 GB), 2x Tesla V100-SXM2-32GB (NVLink), torch 2.7.1+cu118, ComfyUI 0.30.0, default launch (cudaMallocAsync active), `RayInitializer` GPU=2 / ulysses_degree=2 / attention=TORCH_EFFICIENT:
  - **Without this patch**: both workers OOM at sampling step 2, each pinned at ~32.4 GB (`torch.OutOfMemoryError` in `custom_sampler_advanced`). Reproduced 3/3 runs, also with `skip_comm_test=True` and `expandable_segments:True`.
  - **With the backend stripped** (equivalent to relaunching the host with `--disable-cuda-malloc`): the same workflow completes reliably. 12.0 s/it vs 15.28 s/it single-GPU on the same card; output frame statistics identical to the single-GPU result for the same seed.

## Fix

`_build_local_runtime_env()` now injects a sanitized `PYTORCH_CUDA_ALLOC_CONF` into the worker `env_vars`: only the `backend:` option is removed, all other allocator options are preserved. A one-line notice is printed when stripping happens. Users who explicitly want the async allocator in workers can set `RAYLIGHT_KEEP_CUDA_MALLOC_ASYNC=1`.

The host/driver process is not touched — only worker env. Remote clusters are unaffected (workers there don't inherit the driver env).

## Notes

- While testing FSDP on the same setup we also hit `AssertionError: FSDP expects uniform original parameter dtype but got {torch.bfloat16, torch.float32}` from `_pre_init_fsdp` with the quantized H3 checkpoints (quant scales are fp32, LUT/AdaLN params bf16). That's a separate issue — happy to file it with full logs if useful.
- Happy to adjust the opt-out mechanism (env var vs node input) to whatever fits the project style.

Tested on: 2x V100-SXM2-32GB (NVLink), Ubuntu 22.04, Python 3.11, torch 2.7.1+cu118, ComfyUI 0.30.0, raylight @ 349d7a4.
